### PR TITLE
Upgraded the Ruby Kata to RSpec 2 syntax

### DIFF
--- a/ruby/.rspec
+++ b/ruby/.rspec
@@ -1,2 +1,2 @@
 --colour
---format nested
+--format documentation

--- a/ruby/gilded_rose_spec.rb
+++ b/ruby/gilded_rose_spec.rb
@@ -6,7 +6,7 @@ describe GildedRose do
     it "does not change the name" do
       items = [Item.new("foo", 0, 0)]
       GildedRose.new(items).update_quality()
-      items[0].name.should == "fixme"
+      expect(items[0].name).to eq("fixme")
     end
   end
 


### PR DESCRIPTION
Received this error while trying to run rspec.
The nested formatter was used in RSpec 1. This was renamed documentation in RSpec2
http://stackoverflow.com/questions/24688592/rspec-cant-find-nested-formatter