### PR TITLE
Updated for Swift 3

### DIFF
--- a/swift/main.swift
+++ b/swift/main.swift
@@ -14,8 +14,8 @@ let items = [
 let app = GildedRose(items: items);
 
 var days = 2;
-if (Process.argc > 1) {
-    days = Int(Process.arguments[1])! + 1
+if (CommandLine.argc > 1) {
+    days = Int(CommandLine.arguments[1])! + 1
 }
 
 


### PR DESCRIPTION
Process enum has been replaced with CommandLine in Swift 3. Changed main.swift to reflect this.

Fixes #43 