### PR TITLE
Proposed fix for #34: Implement a working version of the original code for the kata

### DIFF
--- a/elixir/lib/gilded_rose.ex
+++ b/elixir/lib/gilded_rose.ex
@@ -1,48 +1,83 @@
 defmodule GildedRose do
   # Example
   # update_quality([%Item{name: "Backstage passes to a TAFKAL80ETC concert", sell_in: 9, quality: 1}])
-  # => [%Item{name: "Backstage passes to a TAFKAL80ETC concert", sell_in: 9, quality: 3}]
+  # => [%Item{name: "Backstage passes to a TAFKAL80ETC concert", sell_in: 8, quality: 3}]
 
   def update_quality(items) do
     Enum.map(items, &update_item/1)
   end
 
   def update_item(item) do
-    cond do
-      item.quality == 0 ->
-        item
-      item.sell_in < 0 && item.name == "Backstage passes to a TAFKAL80ETC concert" ->
-        %{item | quality: 0}
-      item.name == "Aged Brie" || item.name == "Backstage passes to a TAFKAL80ETC concert" ->
-        if item.name == "Backstage passes to a TAFKAL80ETC concert" && item.sell_in > 5 && item.sell_in <= 10 do
-          %{item | quality: item.quality + 2}
-        else
-          if item.name == "Backstage passes to a TAFKAL80ETC concert" && item.sell_in >= 0 && item.sell_in <= 5 do
-            %{item | quality: item.quality + 3}
-          else
-            if item.quality < 50 do
-              %{item | quality: item.quality + 1}
-            else
-              item
-            end
-          end
-        end
-      item.sell_in < 0 ->
-        if item.name == "Backstage passes to a TAFKAL80ETC concert" do
-          %{item | quality: 0}
-        else
-          if item.name == "+5 Dexterity Vest" || item.name == "Elixir of the Mongoose" do
-            %{item | quality: item.quality - 2}
+    item = cond do
+      item.name != "Aged Brie" && item.name != "Backstage passes to a TAFKAL80ETC concert" ->
+        if item.quality > 0 do
+          if item.name != "Sulfuras, Hand of Ragnaros" do
+            %{item | quality: item.quality - 1}
           else
             item
           end
+        else
+          item
         end
-      item.name == "+5 Dexterity Vest" || item.name == "Elixir of the Mongoose" ->
-        %{item | quality: item.quality - 1}
-      item.name != "Sulfuras, Hand of Ragnaros" ->
-        %{item | quality: item.quality - 1}
       true ->
-        item
+        cond do
+          item.quality < 50 ->
+            item = %{item | quality: item.quality + 1}
+            cond do
+              item.name == "Backstage passes to a TAFKAL80ETC concert" ->
+                item = cond do
+                  item.sell_in < 11 ->
+                    cond do
+                      item.quality < 50 ->
+                        %{item | quality: item.quality + 1}
+                      true -> item
+                    end
+                  true -> item
+                end
+                cond do
+                  item.sell_in < 6 ->
+                    cond do
+                      item.quality < 50 ->
+                        %{item | quality: item.quality + 1}
+                      true -> item
+                    end
+                  true -> item
+                end
+              true -> item
+            end
+          true -> item
+        end
+    end
+    item = cond do
+      item.name != "Sulfuras, Hand of Ragnaros" ->
+        %{item | sell_in: item.sell_in - 1}
+      true -> item
+    end
+    cond do
+      item.sell_in < 0 ->
+        cond do
+          item.name != "Aged Brie" ->
+            cond do
+              item.name != "Backstage passes to a TAFKAL80ETC concert" ->
+                cond do
+                  item.quality > 0 ->
+                    cond do
+                      item.name != "Sulfuras, Hand of Ragnaros" ->
+                        %{item | quality: item.quality - 1}
+                      true -> item
+                    end
+                  true -> item
+                end
+              true -> %{item | quality: item.quality - item.quality}
+            end
+          true ->
+            cond do
+              item.quality < 50 ->
+                %{item | quality: item.quality + 1}
+              true -> item
+            end
+        end
+      true -> item
     end
   end
 end


### PR DESCRIPTION
Why:
 - The current version isn't implemented properly.

Additional information:
 - This is the result of my local test run (test omitted since
   they're a part of the kata):

   GildedRoseTest
     * test update_quality/1 Aged Brie actually increases in Quality
       the older it gets
     * test Backstage passes Quality increases by 2 when there are
       10 days or less
     * test update_quality/1 the quality of an item is never negative
     * test update_quality/1 degrades the quality when a day passes
     * test Backstage passes Quality increases by 3 when there are 5
       days or less
     * test update_quality/1 when sell date is passed it degrades twice
       as fast
     * test Backstage passes Quality increases by 1 when sell_in is
       larger than 10
     * test update_quality/1 does not change the name
     * test update_quality/1 The Quality of an item is never more than 50
     * test update_quality/1 Sulfuras, being a legendary item, never has
       to be sold or decreases in Quality
     * test Backstage passes Quality drops to 0 after the concert

   11 tests, 0 failures