### PR TITLE
Aged Brie quality increases by 2 When SellIn <=0

### DIFF
--- a/csharp/GildedRose.cs
+++ b/csharp/GildedRose.cs
@@ -75,15 +75,15 @@ namespace GildedRose
 							Items[i].Quality = Items[i].Quality - Items[i].Quality;
 						}
 					}
-					else
-					{
-						if (Items[i].Quality < 50)
-						{
-							Items[i].Quality = Items[i].Quality + 1;
-						}
-					}
-				}
-			}
+                    //else
+                    //{
+                    //    if (Items[i].Quality < 50)
+                    //    {
+                    //        Items[i].Quality = Items[i].Quality + 1;
+                    //    }
+                    //}
+                }
+            }
 		}
 		
 	}


### PR DESCRIPTION
"Aged Brie"  Quality increases by 1 as SellIn decreases. Line 78 to 84
will make "Aged Brie" Quality increases  by 1 . A unit test for "Aged
Brie" that has a SellIn value of 0 or less will result in a quality
increase of 2. That is incorrect since the requirement states that "Aged
Brie" Quality increases by 1 as SellIn approcahes. Lines 78 to 84 have
been commented out to rectify the problem.