### PR TITLE
Fix cyber dojos

### DIFF
--- a/README.md
+++ b/README.md
@@ -40,7 +40,7 @@ I've also set this kata up on [cyber-dojo](http://cyber-dojo.org) for several la
 - [Ruby](http://cyber-dojo.org/forker/fork/A8943EAF92?avatar=hippo&tag=9)
 - [RSpec, Ruby](http://cyber-dojo.org/forker/fork/8E58B0AD16?avatar=raccoon&tag=3)
 - [Python](http://cyber-dojo.org/forker/fork/297041AA7A?avatar=lion&tag=4)
-- [Cucumber, Java](http://cyber-dojo.org/forker/fork/0F82D4BA89?avatar=gorilla&tag=45) - for this one I've also written some step definitions for you
+- [Cucumber, Java](http://cyber-dojo.org/forker/fork/0F82D4BA89?avatar=gorilla&tag=48) - for this one I've also written some step definitions for you
 
 ## Better Code Hub
 

--- a/README.md
+++ b/README.md
@@ -34,7 +34,7 @@ The Text-Based tests in this repository are designed to be used with the tool "T
 
 I've also set this kata up on [cyber-dojo](http://cyber-dojo.org) for several languages, so you can get going really quickly:
 
-- [JUnit, Java](http://cyber-dojo.org/forker/fork/751DD02C4C?avatar=snake&tag=4)
+- [JUnit, Java](http://cyber-dojo.org/forker/fork/751DD02C4C?avatar=snake&tag=8)
 - [C#](http://cyber-dojo.org/forker/fork/5C5AC766B0?avatar=koala&tag=1)
 - [C++](http://cyber-dojo.org/forker/fork/AA86ECBCC9?avatar=rhino&tag=7)
 - [Ruby](http://cyber-dojo.org/forker/fork/A8943EAF92?avatar=hippo&tag=9)

--- a/README.md
+++ b/README.md
@@ -35,7 +35,7 @@ The Text-Based tests in this repository are designed to be used with the tool "T
 I've also set this kata up on [cyber-dojo](http://cyber-dojo.org) for several languages, so you can get going really quickly:
 
 - [JUnit, Java](http://cyber-dojo.org/forker/fork/751DD02C4C?avatar=snake&tag=8)
-- [C#](http://cyber-dojo.org/forker/fork/5C5AC766B0?avatar=koala&tag=1)
+- [C#](http://cyber-dojo.org/forker/fork/5C5AC766B0?avatar=koala&tag=3)
 - [C++](http://cyber-dojo.org/forker/fork/AA86ECBCC9?avatar=rhino&tag=7)
 - [Ruby](http://cyber-dojo.org/forker/fork/A8943EAF92?avatar=hippo&tag=9)
 - [RSpec, Ruby](http://cyber-dojo.org/forker/fork/8E58B0AD16?avatar=raccoon&tag=3)


### PR DESCRIPTION
Following cyber-dojo.org java katas are broken, Probably because of an upgrade of the cyber-dojo server and its components:
* JUnit, Java
* C#
* Cucumber, Java

I fixed these cyber-dojos and updated the links in the README.md to use the new versions.