### PR TITLE
Update requirements to reflect backstage exclusion/inclusion

### DIFF
--- a/GildedRoseRequirements.txt
+++ b/GildedRoseRequirements.txt
@@ -21,7 +21,7 @@ Pretty simple, right? Well this is where it gets interesting:
 	- The Quality of an item is never more than 50
 	- "Sulfuras", being a legendary item, never has to be sold or decreases in Quality
 	- "Backstage passes", like aged brie, increases in Quality as its SellIn value approaches;
-	Quality increases by 2 when there are 10 days or less and by 3 when there are 5 days or less but
+	Quality increases by 2 when there are less than 10 days and by 3 when there are less than 5 days but
 	Quality drops to 0 after the concert
 
 We have recently signed a supplier of conjured items. This requires an update to our system:


### PR DESCRIPTION
Original requirements suggest that quality should increases at 10 days/5 day inclusively, but tests expect 10/5 to be exclusive. 