### PR TITLE
Added elixir build folder to ignored files

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,4 @@
 .idea/workspace.xml
 *.pyc
 /perl6/lib/.precomp
+/elixir/_build/


### PR DESCRIPTION
Included to the gitignore also the elixir __build_ folder path, as well already done for the perl6 _.precomp_ folder.