### PR TITLE
Added NUnit Test Adapter for discovering test in VS

### DIFF
--- a/csharp/csharp.csproj
+++ b/csharp/csharp.csproj
@@ -1,5 +1,6 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <Project ToolsVersion="14.0" DefaultTargets="Build" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
+  <Import Project="packages\NUnit3TestAdapter.3.9.0\build\net35\NUnit3TestAdapter.props" Condition="Exists('packages\NUnit3TestAdapter.3.9.0\build\net35\NUnit3TestAdapter.props')" />
   <Import Project="$(MSBuildExtensionsPath)\$(MSBuildToolsVersion)\Microsoft.Common.props" Condition="Exists('$(MSBuildExtensionsPath)\$(MSBuildToolsVersion)\Microsoft.Common.props')" />
   <PropertyGroup>
     <Configuration Condition=" '$(Configuration)' == '' ">Debug</Configuration>
@@ -76,6 +77,12 @@
     <Service Include="{82A7F48D-3B50-4B1E-B82E-3ADA8210C358}" />
   </ItemGroup>
   <Import Project="$(MSBuildToolsPath)\Microsoft.CSharp.targets" />
+  <Target Name="EnsureNuGetPackageBuildImports" BeforeTargets="PrepareForBuild">
+    <PropertyGroup>
+      <ErrorText>This project references NuGet package(s) that are missing on this computer. Use NuGet Package Restore to download them.  For more information, see http://go.microsoft.com/fwlink/?LinkID=322105. The missing file is {0}.</ErrorText>
+    </PropertyGroup>
+    <Error Condition="!Exists('packages\NUnit3TestAdapter.3.9.0\build\net35\NUnit3TestAdapter.props')" Text="$([System.String]::Format('$(ErrorText)', 'packages\NUnit3TestAdapter.3.9.0\build\net35\NUnit3TestAdapter.props'))" />
+  </Target>
   <!-- To modify your build process, add your task inside one of the targets below and uncomment it. 
        Other similar extension points exist, see Microsoft.Common.targets.
   <Target Name="BeforeBuild">

--- a/csharp/csharp.csproj
+++ b/csharp/csharp.csproj
@@ -48,9 +48,8 @@
       <HintPath>packages\ApprovalUtilities.3.0.13\lib\net45\ApprovalUtilities.Net45.dll</HintPath>
       <Private>True</Private>
     </Reference>
-    <Reference Include="nunit.framework, Version=3.8.1.0, Culture=neutral, PublicKeyToken=2638cd05610744eb, processorArchitecture=MSIL">
-      <HintPath>packages\NUnit.3.8.1\lib\net45\nunit.framework.dll</HintPath>
-      <Private>True</Private>
+    <Reference Include="nunit.framework, Version=3.9.0.0, Culture=neutral, PublicKeyToken=2638cd05610744eb, processorArchitecture=MSIL">
+      <HintPath>packages\NUnit.3.9.0\lib\net45\nunit.framework.dll</HintPath>
     </Reference>
     <Reference Include="System" />
     <Reference Include="System.Core" />

--- a/csharp/packages.config
+++ b/csharp/packages.config
@@ -2,6 +2,6 @@
 <packages>
   <package id="ApprovalTests" version="3.0.13" targetFramework="net452" />
   <package id="ApprovalUtilities" version="3.0.13" targetFramework="net452" />
-  <package id="NUnit" version="3.8.1" targetFramework="net452" />
+  <package id="NUnit" version="3.9.0" targetFramework="net452" />
   <package id="NUnit3TestAdapter" version="3.9.0" targetFramework="net452" />
 </packages>

--- a/csharp/packages.config
+++ b/csharp/packages.config
@@ -3,4 +3,5 @@
   <package id="ApprovalTests" version="3.0.13" targetFramework="net452" />
   <package id="ApprovalUtilities" version="3.0.13" targetFramework="net452" />
   <package id="NUnit" version="3.8.1" targetFramework="net452" />
+  <package id="NUnit3TestAdapter" version="3.9.0" targetFramework="net452" />
 </packages>


### PR DESCRIPTION
The NUnit-Test-Adapter is needed as either Visual Studio extension or NuGet package so test runners can discover the NUnit tests. I prefer the NuGet package since then it works on every machine that has just checked out the code without installing any additional extensions.

BR