### PR TITLE
Add ApprovalTests for cpp

### DIFF
--- a/cpp/CMakeLists.txt
+++ b/cpp/CMakeLists.txt
@@ -6,25 +6,62 @@ project(cpp)
 set(CMAKE_THREAD_LIBS_INIT pthread)
 
 enable_testing()
-find_package(GTest REQUIRED)
+find_package(GTest)
+
+include(ExternalProject)
+if(NOT ${GTEST_FOUND}) # Download gtest if not installed
+    message("No system gtest use external project")
+    ExternalProject_Add(googletest
+      GIT_REPOSITORY    https://github.com/google/googletest.git
+      GIT_TAG           master
+      SOURCE_DIR        "${CMAKE_BINARY_DIR}/googletest-src"
+      BINARY_DIR        "${CMAKE_BINARY_DIR}/googletest-build"
+      CONFIGURE_COMMAND ""
+      BUILD_COMMAND     ""
+      INSTALL_COMMAND   ""
+      TEST_COMMAND      ""
+    )
+    add_subdirectory(${CMAKE_BINARY_DIR}/googletest-src
+                 ${CMAKE_BINARY_DIR}/googletest-build
+                 EXCLUDE_FROM_ALL)
+    set(GTEST_BOTH_LIBRARIES gtest gtest_main)
+endif()
+
+ExternalProject_Add(aprovaltest
+    PREFIX ${CMAKE_BINARY_DIR}/aprovaltest
+    URL https://github.com/approvals/ApprovalTests.cpp/releases/download/v.2.0.0/ApprovalTests.v.2.0.0.hpp
+    DOWNLOAD_NO_EXTRACT 1
+    CONFIGURE_COMMAND ""
+    BUILD_COMMAND ""
+    INSTALL_COMMAND ""
+)
+
 include_directories(${GTEST_INCLUDE_DIRS})
+include_directories(${CMAKE_BINARY_DIR}/aprovaltest/src)
 
-set(GILDED_ROSE_SOURCE_FILES
+add_executable(GildedRose
     GildedRose.cc
     GildedRose.h
-    GildedRoseUnitTests.cc)
-
-set(GILDED_ROSE_TEXT_TESTS_SOURCE_FILES
-    GildedRose.cc
-    GildedRose.h
-    GildedRoseTextTests.cc)
-
-set(SOURCE_FILES
-    ${GILDED_ROSE_SOURCE_FILES}
-    ${GILDED_ROSE_TEXT_TESTS_SOURCE_FILES})
-
-add_executable(GildedRose ${GILDED_ROSE_SOURCE_FILES})
+    GildedRoseUnitTests.cc
+    )
 target_link_libraries(GildedRose ${GTEST_BOTH_LIBRARIES} ${CMAKE_THREAD_LIBS_INIT})
+add_test(NAME GildedRose COMMAND GildedRose)
 
-add_executable(GildedRoseTextTests ${GILDED_ROSE_TEXT_TESTS_SOURCE_FILES})
+add_executable(GildedRoseTextTests
+    GildedRose.cc
+    GildedRose.h
+    GildedRoseTextTests.cc
+    )
 target_link_libraries(GildedRoseTextTests ${GTEST_BOTH_LIBRARIES} ${CMAKE_THREAD_LIBS_INIT})
+add_test(NAME GildedRoseTextTests COMMAND GildedRoseTextTests)
+
+add_executable(GildedRoseApprovalTests
+    GildedRose.cc
+    GildedRose.h
+    GildedRoseApprovalTests.cc
+    GildedRoseApprovalMain.cc
+    )
+target_link_libraries(GildedRoseApprovalTests ${GTEST_BOTH_LIBRARIES} ${CMAKE_THREAD_LIBS_INIT})
+set_property(TARGET GildedRoseApprovalTests PROPERTY CXX_STANDARD 14)
+add_dependencies(GildedRoseApprovalTests aprovaltest)
+add_test(NAME GildedRoseApprovalTests COMMAND GildedRoseApprovalTests)

--- a/cpp/GildedRoseApprovalMain.cc
+++ b/cpp/GildedRoseApprovalMain.cc
@@ -1,0 +1,2 @@
+#define APPROVALS_GOOGLETEST
+#include "ApprovalTests.v.2.0.0.hpp"

--- a/cpp/GildedRoseApprovalTests.VerifyCombinations.approved.txt
+++ b/cpp/GildedRoseApprovalTests.VerifyCombinations.approved.txt
@@ -1,0 +1,2 @@
+(Foo, 1, 1) => name: Foo, sellIn: 0, quality: 0
+

--- a/cpp/GildedRoseApprovalTests.cc
+++ b/cpp/GildedRoseApprovalTests.cc
@@ -1,0 +1,28 @@
+#include "ApprovalTests.v.2.0.0.hpp"
+#include <gtest/gtest.h>
+#include "GildedRose.h"
+
+std::ostream& operator<<(std::ostream& os, const Item& obj)
+{
+    return os
+        << "name: " << obj.name
+        << ", sellIn: " << obj.sellIn
+        << ", quality: " << obj.quality;
+}
+
+TEST(GildedRoseApprovalTests, VerifyCombinations)
+{
+    std::vector<string> names { "Foo" };
+    std::vector<int> sellIns { 1 };
+    std::vector<int> qualities { 1 };
+
+    CombinationApprovals::verifyAllCombinations<
+        std::vector<string>, std::vector<int>, std::vector<int>, Item>(
+                [](string name, int sellIn, int quality) {
+                vector<Item> items = {Item(name, sellIn, quality)};
+                GildedRose app(items);
+                app.updateQuality();
+                return items[0];
+                },
+                names, sellIns, qualities);
+}

--- a/cpp/run-approval-once.sh
+++ b/cpp/run-approval-once.sh
@@ -1,0 +1,8 @@
+#!/bin/bash
+
+if [[ ! -d build ]]; then
+    mkdir -p build
+fi
+
+cd build
+cmake .. -DCMAKE_BUILD_TYPE=DEBUG && cmake --build . && ctest --output-on-failure -R GildedRoseApprovalTests

--- a/cpp/run-once-cmake.sh
+++ b/cpp/run-once-cmake.sh
@@ -1,0 +1,8 @@
+#!/bin/bash
+
+if [[ ! -d build ]]; then
+    mkdir -p build
+fi
+
+cd build
+cmake .. -DCMAKE_BUILD_TYPE=DEBUG && cmake --build . && ctest --output-on-failure


### PR DESCRIPTION
* Add testcase using https://github.com/approvals/ApprovalTests.cpp and google test.
* Change google test to be downloaded if not installed with cmake
* Add a run-once-cmake.sh script to build and test with cmake
* Add a run-approval-once.sh script to build and run approval test