### PR TITLE
chore(haskell): update base and add stack file

### DIFF
--- a/haskell/README.md
+++ b/haskell/README.md
@@ -1,14 +1,19 @@
 # Haskell port of the Gilded-Rose Kata
 
-This is a Haskell port of the *Gilded-Rose-Kata*. For updates and pull-request
-on this haskell port go to https://github.com/sheyll/gilded-rose-haskell
+This is a Haskell port of the *Gilded-Rose-Kata*. 
+
+## Prerequisite
+
+If you don't have a recent Stack version installed in your system, follow the 
+[installation instructions](https://docs.haskellstack.org/en/stable/install_and_upgrade/) 
+for your operating system. 
 
 ## Building and Running
 
-Run `./install_deps.sh` initially, then `./test.sh` to execute the tests after
+Run `stack build` initially, then `stack test` to execute the tests after
 each refactoring.
 
-To execute the program run `./run.sh [days]` where `[days]` denotes an optional
+To execute the program run `stack run [days]` where `[days]` denotes an optional
 parameter for the number of days to simulate.
 
 Tests are in `test/GildedRoseSpec.hs`. Refer to http://hspec.github.io/ for

--- a/haskell/gilded-rose.cabal
+++ b/haskell/gilded-rose.cabal
@@ -10,15 +10,16 @@ cabal-version:       >=1.10
 
 library
   exposed-modules:   GildedRose
-  build-depends:     base >=4.7 && <4.8
+  build-depends:     base >=4.7
   hs-source-dirs:    src
   default-language:  Haskell2010
 
 executable gilded-rose
   main-is:           Main.hs
-  build-depends:     gilded-rose, base >=4.7 && <4.8
+  build-depends:     gilded-rose, base >=4.7 
   hs-source-dirs:    src
   default-language:  Haskell2010
+  other-modules:     GildedRose
 
 test-suite spec
   type:              exitcode-stdio-1.0
@@ -27,7 +28,7 @@ test-suite spec
   default-language:  Haskell2010
   main-is:           Spec.hs
   other-modules:     GildedRoseSpec
-  build-depends:     base >=4.7 && <4.8
+  build-depends:     base >=4.7
                    , gilded-rose
                    , hspec
                    , hspec-expectations

--- a/haskell/install_deps.sh
+++ b/haskell/install_deps.sh
@@ -1,8 +1,0 @@
-#!/bin/bash
-#
-# Fetch and build all dependencies
-#
-set -eu
-
-cabal install --enable-tests --disable-optimization --dependencies-only
-cabal -v0 configure --enable-tests --disable-optimization

--- a/haskell/run.sh
+++ b/haskell/run.sh
@@ -1,8 +1,0 @@
-#!/bin/bash
-#
-# Rebuild the project and run Main.main with all arguments passed to this
-# script.
-#
-set -eu
-
-cabal -v0 run $@

--- a/haskell/stack.yaml
+++ b/haskell/stack.yaml
@@ -1,0 +1,3 @@
+resolver: lts-12.14
+packages:
+- .

--- a/haskell/test.sh
+++ b/haskell/test.sh
@@ -1,9 +1,0 @@
-#!/bin/bash
-#
-# Rebuild the project and run the hspec based unit tests.  This could have been
-# achieved by 'cabal test' but then the output would not be as colorful.
-#
-set -eu
-
-cabal -v0 build
-./dist/build/spec/spec $@


### PR DESCRIPTION
Hello,

This small pull request updates the haskell base version required by `cabal`, as it seems to be a bit outdated. It also provides a `stack.yml` file and suggests to install `stack` so that shell scripts are not needed anymore (and have been removed to avoid redundancy).

At last, it looks like https://github.com/sheyll/gilded-rose-haskell has not been updated for about 4 years. So, the text that mentions it in the README has also been removed.