### PR TITLE
Fix compile error in TS

### DIFF
--- a/TypeScript/app/gilded-rose.ts
+++ b/TypeScript/app/gilded-rose.ts
@@ -13,7 +13,7 @@ export class Item {
 export class GildedRose {
     items: Array<Item>;
 
-    constructor(items = []) {
+    constructor(items = [] as Array<Item>) {
         this.items = items;
     }
 


### PR DESCRIPTION
Without a type annotation, TS expects the argument in the ctor to be a never[], hence "npm test" fails to even start