### PR TITLE
Update (english) GildedRoseRequirements.txt

### DIFF
--- a/GildedRoseRequirements.txt
+++ b/GildedRoseRequirements.txt
@@ -20,7 +20,7 @@ Pretty simple, right? Well this is where it gets interesting:
 	- "Aged Brie" actually increases in Quality the older it gets
 	- The Quality of an item is never more than 50
 	- "Sulfuras", being a legendary item, never has to be sold or decreases in Quality
-	- "Backstage passes", like aged brie, increases in Quality as its SellIn value approaches;
+	- "Backstage passes", like "Backstage passes to a TAFKAL80ETC concert", increases in Quality as its SellIn value approaches;
 	Quality increases by 2 when there are 10 days or less and by 3 when there are 5 days or less but
 	Quality drops to 0 after the concert
 


### PR DESCRIPTION
"Aged brie" is not a "backstage pass," however "Backstage passes to a TAFKAL80ETC concert" is. 
I'm afraid I'm not very profficient in a lot of other languages, that've made a verbatim translation.