### PR TITLE
migrate to JUnit 5

### DIFF
--- a/Java/pom.xml
+++ b/Java/pom.xml
@@ -11,13 +11,15 @@
 
     <properties>
         <java.version>1.8</java.version>
+        <junit.jupiter.version>5.5.2</junit.jupiter.version>
+        <maven.maven-surefire-plugin.version>2.22.2</maven.maven-surefire-plugin.version>
     </properties>
 
     <dependencies>
         <dependency>
-            <groupId>junit</groupId>
-            <artifactId>junit</artifactId>
-            <version>4.12</version>
+            <groupId>org.junit.jupiter</groupId>
+            <artifactId>junit-jupiter</artifactId>
+            <version>${junit.jupiter.version}</version>
             <scope>test</scope>
         </dependency>
     </dependencies>
@@ -30,6 +32,10 @@
                     <source>${java.version}</source>
                     <target>${java.version}</target>
                 </configuration>
+            </plugin>
+            <plugin>
+                <artifactId>maven-surefire-plugin</artifactId>
+                <version>${maven.maven-surefire-plugin.version}</version>
             </plugin>
         </plugins>
     </build>

--- a/Java/src/test/java/com/gildedrose/GildedRoseTest.java
+++ b/Java/src/test/java/com/gildedrose/GildedRoseTest.java
@@ -1,13 +1,13 @@
 package com.gildedrose;
 
-import static org.junit.Assert.*;
+import org.junit.jupiter.api.Test;
 
-import org.junit.Test;
+import static org.junit.jupiter.api.Assertions.assertEquals;
 
-public class GildedRoseTest {
+class GildedRoseTest {
 
     @Test
-    public void foo() {
+    void foo() {
         Item[] items = new Item[] { new Item("foo", 0, 0) };
         GildedRose app = new GildedRose(items);
         app.updateQuality();


### PR DESCRIPTION
As JUnit 5 is the new major version for over 2 years now, I thought it would be time to get rid of legacy versions ;-)