### PR TITLE
Reduce required C++ level from 17 to 11 - no code changes needed.

### DIFF
--- a/cpp/README.md
+++ b/cpp/README.md
@@ -15,7 +15,7 @@ The `GildedRose.cc` file, i.e. the code under test, is identical in all four var
 ## Prerequisites
 
 * CMake version >= 3.13
-* C++ compiler that support C++17
+* C++ compiler that support C++11
 
 ## How to build and run tests in a terminal
 

--- a/cpp/test/cpp_catch2_approvaltest/CMakeLists.txt
+++ b/cpp/test/cpp_catch2_approvaltest/CMakeLists.txt
@@ -2,7 +2,7 @@ set(TEST_NAME GildedRoseCatch2ApprovalTests)
 add_executable(${TEST_NAME})
 target_sources(${TEST_NAME} PRIVATE GildedRoseCatch2ApprovalTests.cc)
 target_link_libraries(${TEST_NAME} lib src)
-set_property(TARGET ${TEST_NAME} PROPERTY CXX_STANDARD 17)
+set_property(TARGET ${TEST_NAME} PROPERTY CXX_STANDARD 11)
 add_test(NAME ${TEST_NAME} COMMAND ${TEST_NAME})
 
 # Set compiler option /FC for Visual Studio to to make the __FILE__ macro expand to full path. 

--- a/cpp/test/cpp_catch2_unittest/CMakeLists.txt
+++ b/cpp/test/cpp_catch2_unittest/CMakeLists.txt
@@ -2,7 +2,7 @@ set(TEST_NAME GildedRoseCatch2UnitTests)
 add_executable(${TEST_NAME})
 target_sources(${TEST_NAME} PRIVATE GildedRoseCatch2UnitTests.cc)
 target_link_libraries(${TEST_NAME} lib src)
-set_property(TARGET ${TEST_NAME} PROPERTY CXX_STANDARD 17)
+set_property(TARGET ${TEST_NAME} PROPERTY CXX_STANDARD 11)
 add_test(NAME ${TEST_NAME} COMMAND ${TEST_NAME})
 
 # Set compiler option /FC for Visual Studio to to make the __FILE__ macro expand to full path. 

--- a/cpp/test/cpp_googletest_approvaltest/CMakeLists.txt
+++ b/cpp/test/cpp_googletest_approvaltest/CMakeLists.txt
@@ -2,7 +2,7 @@ set(TEST_NAME GildedRoseGoogletestApprovalTests)
 add_executable(${TEST_NAME})
 target_sources(${TEST_NAME} PRIVATE googletest_approval_main.cc GildedRoseGoogletestApprovalTests.cc)
 target_link_libraries(${TEST_NAME} lib src gtest)
-set_property(TARGET ${TEST_NAME} PROPERTY CXX_STANDARD 17)
+set_property(TARGET ${TEST_NAME} PROPERTY CXX_STANDARD 11)
 add_test(NAME ${TEST_NAME} COMMAND ${TEST_NAME})
 
 # Set compiler option /FC for Visual Studio to to make the __FILE__ macro expand to full path. 

--- a/cpp/test/cpp_googletest_unittest/CMakeLists.txt
+++ b/cpp/test/cpp_googletest_unittest/CMakeLists.txt
@@ -2,7 +2,7 @@ set(TEST_NAME GildedRoseGoogletestUnitTests)
 add_executable(${TEST_NAME})
 target_sources(${TEST_NAME} PRIVATE GildedRoseGoogletestUnitTests.cc)
 target_link_libraries(${TEST_NAME} src gtest gtest_main)
-set_property(TARGET ${TEST_NAME} PROPERTY CXX_STANDARD 17)
+set_property(TARGET ${TEST_NAME} PROPERTY CXX_STANDARD 11)
 add_test(NAME ${TEST_NAME} COMMAND ${TEST_NAME})
 
 # Set compiler option /FC for Visual Studio to to make the __FILE__ macro expand to full path. 


### PR DESCRIPTION
This is a minor change to the excellent #133 - to allow support for C++11 and C++14...

It updates both the CMake files and the readme.