### PR TITLE
Remove quality change on sulfuras

### DIFF
--- a/php7/src/GildedRose.php
+++ b/php7/src/GildedRose.php
@@ -16,8 +16,6 @@ final class GildedRose {
                 if ($item->quality > 0) {
                     if ($item->name != 'Sulfuras, Hand of Ragnaros') {
                         $item->quality = $item->quality - 1;
-                    } else {
-                        $item->quality = 80;
                     }
                 }
             } else {


### PR DESCRIPTION
For some reason the php7 version sets the quality of sulfuras to be 80.
The sepcification simply states this is the max, and that it does not change, as 
written on line 22 of the english specifications.:
https://github.com/emilybache/GildedRose-Refactoring-Kata/blob/master/GildedRoseRequirements.txt#L22