### PR TITLE
Remove broken links to cyber-dojo from README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -24,28 +24,6 @@ Whichever testing approach you choose, the idea of the exercise is to do some de
 
 This code comes with comprehensive tests that use this approach. For information about how to run them, see the [texttests README](https://github.com/emilybache/GildedRose-Refactoring-Kata/tree/master/texttests)
 
-## Get going quickly using Cyber-Dojo
-
-I've also set this kata up on [cyber-dojo](https://cyber-dojo.org) for several languages, so you can get going really quickly:
-
-To create an *individual* exercise:
-- [C#, NUnit](https://cyber-dojo.org/forker/fork_individual/Fz4xFX?index=3)
-- [C++ (g++), GoogleTest](https://cyber-dojo.org/forker/fork_individual/qPPrZy?index=7)
-- [Java, Cucumber](https://cyber-dojo.org/forker/fork_individual/SvUf30?index=2) - for this one I've also written some step definitions for you
-- [Java, JUnit](https://cyber-dojo.org/forker/fork_individual/aJJEN4?index=2)
-- [Python, unittest](https://cyber-dojo.org/forker/fork_individual/NFgFys?index=2)
-- [Ruby, RSpec](https://cyber-dojo.org/forker/fork_individual/D3xbUV?index=3)
-- [Ruby, testunit](https://cyber-dojo.org/forker/fork_individual/zlElgj?index=9)
-
-To create a *group* exercise:
-- [C#, NUnit](https://cyber-dojo.org/forker/fork_group/Fz4xFX?index=3)
-- [C++ (g++), GoogleTest](https://cyber-dojo.org/forker/fork_group/qPPrZy?index=7)
-- [Java, Cucumber](https://cyber-dojo.org/forker/fork_group/SvUf30?index=2) - for this one I've also written some step definitions for you
-- [Java, JUnit](https://cyber-dojo.org/forker/fork_group/aJJEN4?index=2)
-- [Python, unittest](https://cyber-dojo.org/forker/fork_group/NFgFys?index=2)
-- [Ruby, RSpec](https://cyber-dojo.org/forker/fork_group/D3xbUV?index=3)
-- [Ruby, testunit](https://cyber-dojo.org/forker/fork_group/zlElgj?index=9)
-
 ## Better Code Hub
 
 I analysed this repo according to the clean code standards on [Better Code Hub](https://bettercodehub.com) just to get an independent opinion of how bad the code is. Perhaps unsurprisingly, the compliance score is low!


### PR DESCRIPTION
Like the the README.md files for Racing-Car-Katas and the Tennis-Refactoring-Kata did, this README.md for GildedRose-Refactoring-Kata has. 

**(This is my last PR about cyber-dojo. I noticed this issue on the two repos I used recently. I won't be going on a hunt through other repos.)**