### PR TITLE
Make rust text based approval tests pass

### DIFF
--- a/rust/src/main.rs
+++ b/rust/src/main.rs
@@ -18,7 +18,7 @@ fn main() {
     let mut rose = GildedRose::new(items);
 
     println!("OMGHAI!");
-    for i in 0..30 {
+    for i in 0..=30 {
         println!("-------- day {} --------", i);
         println!("name, sellIn, quality");
         for item in &rose.items {


### PR DESCRIPTION
The main method for approval tests are supposed to run 30 days.
Previous impl was using an exclusive range.
Use an inclusive range instead.