### PR TITLE
Fix texttest Java classpath for maven and gradle builds

### DIFF
--- a/texttests/environment.gr
+++ b/texttests/environment.gr
@@ -1,3 +1,3 @@
 # If your .class files are somewhere else, add the path to the list
-CLASSPATH:${TEXTTEST_HOME}/Java:${TEXTTEST_HOME}/Java/bin
+CLASSPATH:${TEXTTEST_HOME}/Java/build/classes/java/test;${TEXTTEST_HOME}/Java/build/classes/java/main;${TEXTTEST_HOME}/Java/target/classes;${TEXTTEST_HOME}/Java/target/test-classes
 PERL5OPT:-I${TEXTTEST_HOME}/perl


### PR DESCRIPTION
The suggested texttest environment config Java (classpath), doesn't work with the default maven/gradle build directories.

This change should fix the issue.

Co-Authored-By: Kristóf Juhász <76943150+kristof-juhasz@users.noreply.github.com>
Co-Authored-By: mariettas <47053959+mariettas@users.noreply.github.com>
Co-Authored-By: Marc Monserrat Núñez <32415447+munsa@users.noreply.github.com>
Co-Authored-By: Mauro Ceraso <76943029+mauroceraso@users.noreply.github.com>
Co-Authored-By: Norbert Toth <75730727+norbertgabortoth@users.noreply.github.com>