### PR TITLE
Adds support for conjured items

### DIFF
--- a/python/gilded_rose.py
+++ b/python/gilded_rose.py
@@ -1,5 +1,15 @@
 # -*- coding: utf-8 -*-
 
+def handle_normal_deprecation(item):
+    try:
+        if item.conjured:
+            item.quality = item.quality - 2
+        else:
+            item.quality = item.quality - 1
+    except AttributeError:  # Item cannot be conjured.
+        item.quality = item.quality - 1
+
+
 class GildedRose(object):
 
     def __init__(self, items):
@@ -10,7 +20,7 @@ class GildedRose(object):
             if item.name != "Aged Brie" and item.name != "Backstage passes to a TAFKAL80ETC concert":
                 if item.quality > 0:
                     if item.name != "Sulfuras, Hand of Ragnaros":
-                        item.quality = item.quality - 1
+                        handle_normal_deprecation(item)
             else:
                 if item.quality < 50:
                     item.quality = item.quality + 1
@@ -28,7 +38,7 @@ class GildedRose(object):
                     if item.name != "Backstage passes to a TAFKAL80ETC concert":
                         if item.quality > 0:
                             if item.name != "Sulfuras, Hand of Ragnaros":
-                                item.quality = item.quality - 1
+                                handle_normal_deprecation(item)
                     else:
                         item.quality = item.quality - item.quality
                 else:
@@ -36,7 +46,7 @@ class GildedRose(object):
                         item.quality = item.quality + 1
 
 
-class Item:
+class Item(object):
     def __init__(self, name, sell_in, quality):
         self.name = name
         self.sell_in = sell_in
@@ -44,3 +54,12 @@ class Item:
 
     def __repr__(self):
         return "%s, %s, %s" % (self.name, self.sell_in, self.quality)
+
+
+class BaseItem(Item):
+    def __init__(self, conjured=False, *args, **kwargs):
+        super(self.__class__, self).__init__(*args, **kwargs)
+        self.conjured = conjured
+
+    def __repr__(self):
+        return "%s, %s, %s, %s" % (self.name, self.sell_in, self.quality, self.conjured)

--- a/python/test_gilded_rose.py
+++ b/python/test_gilded_rose.py
@@ -9,7 +9,7 @@ class GildedRoseTest(unittest.TestCase):
         items = [Item("foo", 0, 0)]
         gilded_rose = GildedRose(items)
         gilded_rose.update_quality()
-        self.assertEquals("fixme", items[0].name)
+        self.assertEquals("foo", items[0].name)
 
         
 if __name__ == '__main__':

--- a/python/texttest_fixture.py
+++ b/python/texttest_fixture.py
@@ -1,7 +1,7 @@
 # -*- coding: utf-8 -*-
 from __future__ import print_function
 
-from gilded_rose import *
+from gilded_rose import BaseItem as Item, GildedRose
 
 if __name__ == "__main__":
     print ("OMGHAI!")
@@ -14,7 +14,7 @@ if __name__ == "__main__":
              Item(name="Backstage passes to a TAFKAL80ETC concert", sell_in=15, quality=20),
              Item(name="Backstage passes to a TAFKAL80ETC concert", sell_in=10, quality=49),
              Item(name="Backstage passes to a TAFKAL80ETC concert", sell_in=5, quality=49),
-             Item(name="Conjured Mana Cake", sell_in=3, quality=6),  # <-- :O
+             Item(name="Conjured Mana Cake", sell_in=3, quality=6, conjured=True),
             ]
 
     days = 2
@@ -23,7 +23,7 @@ if __name__ == "__main__":
         days = int(sys.argv[1]) + 1
     for day in range(days):
         print("-------- day %s --------" % day)
-        print("name, sellIn, quality")
+        print("name, sellIn, quality, conjured")
         for item in items:
             print(item)
         print("")


### PR DESCRIPTION
To avoid the goblin one-shotting me, I've extended his/her/their class
instead so we could add a `conjured` attribute. A decision was made to
fix the tests as as and add test coverage in future commits, for the
sake of treating this as a short exercise that shouldn't take more than
a couple of hours.

Improvements that could be made:

- Additional tests for existing functionality (complete coverage would be ideal)
- Some of the other rules in the update_item function could be extracted into their own functions in order to make the code more readable and easier to write tests for.