### PR TITLE
Dart : Fix sdk constraint and update test deps

### DIFF
--- a/dart/pubspec.yaml
+++ b/dart/pubspec.yaml
@@ -2,5 +2,8 @@ name: gilded_rose
 version: 0.0.1
 description: A simple console application.
 
+environment:
+  sdk: '>=2.10.0 <3.0.0'
+
 dev_dependencies:
-  test: '>=0.12.11 <0.13.0'
+  test: ^1.16.8


### PR DESCRIPTION
As of Dart 2.12, omitting the SDK constraint is an error. When the pubspec has no SDK constraint, pub get fails with a message like the following:
```yaml
# pubspec.yaml has no lower-bound SDK constraint.
# You should edit pubspec.yaml to contain an SDK constraint:

environment:
  sdk: '>=2.10.0 <3.0.0'
```
This PR fix that issue and update test dependcy to support the latest dart version. More [here](https://dart.dev/tools/pub/pubspec#sdk-constraints)