### PR TITLE
Update dependencies for JavaScript

### DIFF
--- a/js-jasmine/package.json
+++ b/js-jasmine/package.json
@@ -21,16 +21,19 @@
   },
   "homepage": "https://github.com/emilybache/GildedRose-Refactoring-Kata",
   "devDependencies": {
-    "babel-core": "^6.26.0",
-    "babel-preset-env": "1.7.0",
-    "babel-register": "^6.26.0",
-    "jasmine": "^3.2.0"
+    "@babel/core": "^7.14.0",
+    "@babel/preset-env": "7.14.0",
+    "@babel/register": "^7.13.0",
+    "jasmine": "^3.7.0"
   },
   "babel": {
     "presets": [
       [
-        "env", {
-          "targets": { "node": "current" }
+        "env",
+        {
+          "targets": {
+            "node": "current"
+          }
         }
       ]
     ],

--- a/js-mocha/package.json
+++ b/js-mocha/package.json
@@ -3,7 +3,7 @@
   "version": "1.0.0",
   "description": "Gilded Rose kata in Javascript with Mocha",
   "scripts": {
-    "test": "mocha --compilers js:babel/register"
+    "test": "mocha --require @babel/register"
   },
   "repository": {
     "type": "git",
@@ -21,8 +21,10 @@
   },
   "homepage": "https://github.com/emilybache/GildedRose-Refactoring-Kata",
   "devDependencies": {
-    "babel": "^5.8.23",
+    "@babel/core": "^7.14.0",
+    "@babel/preset-env": "^7.14.0",
+    "@babel/register": "^7.13.0",
     "chai": "^4.2.0",
-    "mocha": "^5.2.0"
+    "mocha": "^8.4.0"
   }
 }


### PR DESCRIPTION
Update to Babel 7 to avoid stern warnings during `npm install`
Update Mocha to version 8, also to avoid warnings and be compatible with
Babel 7