### PR TITLE
Add editorconfig file for Java

### DIFF
--- a/Java/.editorconfig
+++ b/Java/.editorconfig
@@ -1,0 +1,6 @@
+[*]
+charset = utf-8
+indent_size = 4
+indent_style = space
+insert_final_newline = true
+trim_trailing_whitespace = true


### PR DESCRIPTION
[Editorconfig](https://editorconfig.org/) is a great way to make configuration consistent across various IDEs, and works [out-of-the-box](https://editorconfig.org/#pre-installed) with the most popular editors, IntelliJ IDEA included.

Rationale of the PR: my user-level preferences is an indentation size of 2, but the Java project uses a width of 4. So when I reformat the whole document, every lines are changed; and that’s not what we want.

Maybe the file `Java/.editorconfig` could be brought at the project root, but I’m not an expert in other languages.