### PR TITLE
Adding fix for mingw32 compiling on windows

### DIFF
--- a/cpp-catch2/CMakeLists.txt
+++ b/cpp-catch2/CMakeLists.txt
@@ -32,6 +32,11 @@ target_include_directories(approvaltests
         INTERFACE ${catch2_SOURCE_DIR}/single_include/catch2
         )
 
+if( MINGW ) 
+  # https://stackoverflow.com/questions/31890021/mingw-too-many-sections-bug-while-compiling-huge-header-file-in-qt
+  set (CMAKE_CXX_FLAGS "-Wa,-mbig-obj ")
+endif()
+
 add_executable(gildedrose_catch2
         src/GildedRose.h
         src/GildedRose.cc
@@ -41,6 +46,8 @@ set_target_properties(gildedrose_catch2 PROPERTIES CXX_STANDARD 11)
 target_include_directories(gildedrose_catch2
         PUBLIC src)
 target_link_libraries(gildedrose_catch2 Catch2::Catch2 approvaltests)
+
+
 
 include(CTest)
 include(ParseAndAddCatchTests)


### PR DESCRIPTION
mingw32 compiler on windows gave me following error. This PR should fix it for cpp-catch2

Build error
```
Consolidate compiler generated dependencies of target gildedrose_catch2
[ 25%] Building CXX object CMakeFiles/gildedrose_catch2.dir/test/main.cpp.obj
c:/programdata/chocolatey/lib/mingw/tools/install/mingw64/bin/../lib/gcc/x86_64-w64-mingw32/10.2.0/../../../../x86_64-w64-mingw32/bin/as.exe: CMakeFiles\gildedrose_catch2.dir\test\main.cpp.obj: too many sections (34736)
C:\Users\xr3\AppData\Local\Temp\ccmD84Ej.s: Assembler messages:
C:\Users\xr3\AppData\Local\Temp\ccmD84Ej.s: Fatal error: can't write 180 bytes to section .text of CMakeFiles\gildedrose_catch2.dir\test\main.cpp.obj: 'file too big'
c:/programdata/chocolatey/lib/mingw/tools/install/mingw64/bin/../lib/gcc/x86_64-w64-mingw32/10.2.0/../../../../x86_64-w64-mingw32/bin/as.exe: CMakeFiles\gildedrose_catch2.dir\test\main.cpp.obj: too many sections (34736)
C:\Users\xr3\AppData\Local\Temp\ccmD84Ej.s: Fatal error: can't close CMakeFiles\gildedrose_catch2.dir\test\main.cpp.obj: file too big
mingw32-make[2]: *** [CMakeFiles\gildedrose_catch2.dir\build.make:106: CMakeFiles/gildedrose_catch2.dir/test/main.cpp.obj] Error 1
mingw32-make[1]: *** [CMakeFiles\Makefile2:126: CMakeFiles/gildedrose_catch2.dir/all] Error 2
mingw32-make: *** [Makefile:100: all] Error 2

```