### PR TITLE
Update csharpcore's .NET version and dependencies

### DIFF
--- a/csharpcore/csharpcore.csproj
+++ b/csharpcore/csharpcore.csproj
@@ -2,7 +2,7 @@
 
   <PropertyGroup>
     <OutputType>Exe</OutputType>
-    <TargetFramework>netcoreapp2.1</TargetFramework>
+    <TargetFramework>netcoreapp3.1</TargetFramework>
     <StartupObject>csharpcore.Program</StartupObject>
   </PropertyGroup>
 

--- a/csharpcore/csharpcore.csproj
+++ b/csharpcore/csharpcore.csproj
@@ -7,9 +7,9 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="ApprovalTests" Version="4.2.0" />
-    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="15.7.0" />
-    <PackageReference Include="xunit" Version="2.3.1" />
-    <PackageReference Include="xunit.runner.visualstudio" Version="2.3.1" />
+    <PackageReference Include="ApprovalTests" Version="5.5.0" />
+    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="16.10.0" />
+    <PackageReference Include="xunit" Version="2.4.1" />
+    <PackageReference Include="xunit.runner.visualstudio" Version="2.4.3" />
   </ItemGroup>
 </Project>


### PR DESCRIPTION
I upgraded the csharpcore project from .NET Core 2.1 to the new LTS version: .NET Core 3.1. This is because the current version loses support on the 21st August 2021, and running the latest LTS is good practice. For more information, see [the .NET product lifecycle on Microsoft's website](https://docs.microsoft.com/en-us/lifecycle/products/microsoft-net-and-net-core).

I updated the csharpcore project's dependencies. This reduces the risk of people running into bugs or reading the wrong docs when completing this exercise. I ran the program and the tests after each package was upgraded to ensure that no compiler
warnings or changes in behavior were introduced.

![Zoidberg from Futurama saying "Hooray, I'm useful! I'm having a wonderful time!"](https://media.giphy.com/media/ndDR192PNKd2g/giphy.gif)