### PR TITLE
Update Swift Package Manager, clean up starting test, add README

### DIFF
--- a/swift/Package.swift
+++ b/swift/Package.swift
@@ -1,4 +1,4 @@
-// swift-tools-version:5.1
+// swift-tools-version:5.3
 
 import PackageDescription
 

--- a/swift/README.md
+++ b/swift/README.md
@@ -1,0 +1,12 @@
+## Build and test using any of the following
+
+Command line:
+- `swift test`
+
+Xcode:
+- Open this "swift" folder to open package
+- In the Xcode menu, select Product > Test to run tests
+
+AppCode:
+- Open this "swift" folder to open package
+- Select "GildedRoseTests" configuration and run

--- a/swift/Sources/GildedRose/GildedRose.swift
+++ b/swift/Sources/GildedRose/GildedRose.swift
@@ -1,12 +1,12 @@
 public class GildedRose {
-    var items:[Item]
+    var items: [Item]
     
-    public init(items:[Item]) {
+    public init(items: [Item]) {
         self.items = items
     }
     
     public func updateQuality() {
-        for i in 0..<items.count {
+        for i in 0 ..< items.count {
             if (items[i].name != "Aged Brie" && items[i].name != "Backstage passes to a TAFKAL80ETC concert") {
                 if (items[i].quality > 0) {
                     if (items[i].name != "Sulfuras, Hand of Ragnaros") {

--- a/swift/Tests/GildedRoseTests/GildedRoseTests.swift
+++ b/swift/Tests/GildedRoseTests/GildedRoseTests.swift
@@ -5,8 +5,8 @@ class GildedRoseTests: XCTestCase {
 
     func testFoo() {
         let items = [Item(name: "foo", sellIn: 0, quality: 0)]
-        let app = GildedRose(items: items);
-        app.updateQuality();
+        let app = GildedRose(items: items)
+        app.updateQuality()
         XCTAssertEqual("fixme", app.items[0].name);
     }
 

--- a/swift/Tests/GildedRoseTests/GildedRoseTests.swift
+++ b/swift/Tests/GildedRoseTests/GildedRoseTests.swift
@@ -7,7 +7,7 @@ class GildedRoseTests: XCTestCase {
         let items = [Item(name: "foo", sellIn: 0, quality: 0)]
         let app = GildedRose(items: items)
         app.updateQuality()
-        XCTAssertEqual("fixme", app.items[0].name)
+        XCTAssertEqual(app.items[0].name, "fixme")
     }
 
     static var allTests = [

--- a/swift/Tests/GildedRoseTests/GildedRoseTests.swift
+++ b/swift/Tests/GildedRoseTests/GildedRoseTests.swift
@@ -10,9 +10,7 @@ class GildedRoseTests: XCTestCase {
         XCTAssertEqual("fixme", app.items[0].name);
     }
 
-    static var allTests : [(String, (GildedRoseTests) -> () throws -> Void)] {
-        return [
-            ("testFoo", testFoo),
-        ]
-    }
+    static var allTests = [
+        ("testFoo", testFoo),
+    ]
 }

--- a/swift/Tests/GildedRoseTests/GildedRoseTests.swift
+++ b/swift/Tests/GildedRoseTests/GildedRoseTests.swift
@@ -7,7 +7,7 @@ class GildedRoseTests: XCTestCase {
         let items = [Item(name: "foo", sellIn: 0, quality: 0)]
         let app = GildedRose(items: items)
         app.updateQuality()
-        XCTAssertEqual("fixme", app.items[0].name);
+        XCTAssertEqual("fixme", app.items[0].name)
     }
 
     static var allTests = [

--- a/swift/Tests/GildedRoseTests/GildedRoseTests.swift
+++ b/swift/Tests/GildedRoseTests/GildedRoseTests.swift
@@ -3,7 +3,7 @@ import XCTest
 
 class GildedRoseTests: XCTestCase {
 
-    func testFoo() {
+    func testFoo() throws {
         let items = [Item(name: "foo", sellIn: 0, quality: 0)]
         let app = GildedRose(items: items)
         app.updateQuality()


### PR DESCRIPTION
The new version of `swift-tools-version` makes things easier… especially for adding new dependencies like the Swift version of ApprovalTests.

And while formatting is not universal, these spaces are much, much more common. Otherwise my eyes cross.

Updated test code to latest style. In particular, defining the test as `throws` makes it easier to use ApprovalTests.