### PR TITLE
Add initial failing test for Elixir

### DIFF
--- a/elixir/test/gilded_rose_test.exs
+++ b/elixir/test/gilded_rose_test.exs
@@ -2,5 +2,9 @@ defmodule GildedRoseTest do
   use ExUnit.Case
 
   test "begin the journey of refactoring" do
+    items = [%Item{name: "foo", sell_in: 0, quality: 0}]
+    GildedRose.update_quality(items)
+    %{name: firstItemName} = List.first(items)
+    assert "fixme" == firstItemName
   end
 end


### PR DESCRIPTION
I noticed there was a placeholder for an Elixir unit test, but with no assertion, so it passed by default. I wrote a failing test to match the implementations in other languages.