### PR TITLE
Fix JetBrains erlang link

### DIFF
--- a/erlang/README.md
+++ b/erlang/README.md
@@ -1,7 +1,7 @@
 GildedRose
 =====
 
-You will need to install [erlang](https://www.erlang.org/), and [rebar3](https://github.com/erlang/rebar3). I recommend following the instructions from JetBrains: [Getting Started with Erlang](https://www.jetbrains.com/help/idea/getting-started-with-erlang.html).
+You will need to install [erlang](https://www.erlang.org/), and [rebar3](https://github.com/erlang/rebar3). I recommend following the instructions from JetBrains: [Getting Started with Erlang](https://www.jetbrains.com/help/idea/erlang.html).
 
 When you open this project with IntelliJ I recommend that you do 
 


### PR DESCRIPTION
It looks like the link to the JetBrains Erlang information has changed. 