### PR TITLE
Fix Maven warnings

### DIFF
--- a/Java/pom.xml
+++ b/Java/pom.xml
@@ -12,7 +12,9 @@
     <properties>
         <java.version>1.8</java.version>
         <junit.jupiter.version>5.6.2</junit.jupiter.version>
+        <maven.maven-compiler-plugin.version>3.1</maven.maven-compiler-plugin.version>
         <maven.maven-surefire-plugin.version>3.0.0-M4</maven.maven-surefire-plugin.version>
+        <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
     </properties>
 
     <dependencies>
@@ -28,6 +30,7 @@
         <plugins>
             <plugin>
                 <artifactId>maven-compiler-plugin</artifactId>
+                <version>${maven.maven-compiler-plugin.version}</version>
                 <configuration>
                     <source>${java.version}</source>
                     <target>${java.version}</target>


### PR DESCRIPTION
Fixes the following warnings:

```
[WARNING] 
[WARNING] Some problems were encountered while building the effective model for com.gildedrose:gilded-rose-kata:jar:0.0.1-SNAPSHOT
[WARNING] 'build.plugins.plugin.version' for org.apache.maven.plugins:maven-compiler-plugin is missing. @ line 29, column 21
[WARNING] 
[WARNING] It is highly recommended to fix these problems because they threaten the stability of your build.
[WARNING] 
[WARNING] For this reason, future Maven versions might no longer support building such malformed projects.
[WARNING] 
```

and

```
[WARNING] Using platform encoding (UTF-8 actually) to copy filtered resources, i.e. build is platform dependent!
```