### PR TITLE
Update the Swift starting point

### DIFF
--- a/swift/.gitignore
+++ b/swift/.gitignore
@@ -3,3 +3,5 @@
 /Packages
 /*.xcodeproj
 xcuserdata/
+DerivedData/
+.swiftpm/xcode/package.xcworkspace/contents.xcworkspacedata

--- a/swift/Package.swift
+++ b/swift/Package.swift
@@ -1,4 +1,4 @@
-// swift-tools-version:5.3
+// swift-tools-version:5.5
 
 import PackageDescription
 

--- a/swift/Tests/GildedRoseTests/GildedRoseTests.swift
+++ b/swift/Tests/GildedRoseTests/GildedRoseTests.swift
@@ -9,8 +9,4 @@ class GildedRoseTests: XCTestCase {
         app.updateQuality()
         XCTAssertEqual(app.items[0].name, "fixme")
     }
-
-    static var allTests = [
-        ("testFoo", testFoo),
-    ]
 }

--- a/swift/Tests/GildedRoseTests/XCTestManifests.swift
+++ b/swift/Tests/GildedRoseTests/XCTestManifests.swift
@@ -1,9 +1,0 @@
-import XCTest
-
-#if !canImport(ObjectiveC)
-public func allTests() -> [XCTestCaseEntry] {
-    return [
-        testCase(GildedRoseTests.allTests),
-    ]
-}
-#endif

--- a/swift/Tests/LinuxMain.swift
+++ b/swift/Tests/LinuxMain.swift
@@ -1,7 +1,0 @@
-import XCTest
-
-import GildedRoseTests
-
-var tests = [XCTestCaseEntry]()
-tests += GildedRoseTests.allTests()
-XCTMain(tests)


### PR DESCRIPTION
- Ignore the generated Xcode project from the repositiory
- Bump the swift tools version to 5.5 (supported by Xcode 13+)
- Tidy the Tests. LinuxMain, XCTestManifests and the allTests array are no longer needed as tests are auto-discovered on non-apple platforms