### PR TITLE
approval tests for java analog to csharp variant

### DIFF
--- a/Java/pom.xml
+++ b/Java/pom.xml
@@ -24,6 +24,11 @@
             <version>${junit.jupiter.version}</version>
             <scope>test</scope>
         </dependency>
+        <dependency>
+            <groupId>com.approvaltests</groupId>
+            <artifactId>approvaltests</artifactId>
+            <version>12.1.1</version>
+        </dependency>
     </dependencies>
 
     <build>

--- a/Java/src/main/java/com/gildedrose/Program.java
+++ b/Java/src/main/java/com/gildedrose/Program.java
@@ -1,0 +1,32 @@
+package com.gildedrose;
+
+public class Program {
+
+	public static void main(String... args) {
+		System.out.println("OMGHAI!");
+
+		Item[] items = new Item[] { 
+				new Item("+5 Dexterity Vest", 10, 20), 
+				new Item("Aged Brie", 2, 0),
+				new Item("Elixir of the Mongoose", 5, 7), 
+				new Item("Sulfuras, Hand of Ragnaros", 0, 80),
+				new Item("Sulfuras, Hand of Ragnaros", -1, 80),
+				new Item("Backstage passes to a TAFKAL80ETC concert", 15, 20),
+				new Item("Backstage passes to a TAFKAL80ETC concert", 10, 49),
+				new Item("Backstage passes to a TAFKAL80ETC concert", 5, 49),
+				// this conjured item does not work properly yet
+				new Item("Conjured Mana Cake", 3, 6) };
+
+		GildedRose app = new GildedRose(items);
+
+		for (int i = 0; i < 31; i++) {
+			System.out.println("-------- day " + i + " --------");
+			System.out.println("name, sellIn, quality");
+			for (int j = 0; j < items.length; j++) {
+				System.out.println(items[j]);
+			}
+			System.out.println("");
+			app.updateQuality();
+		}
+	}
+}

--- a/Java/src/test/java/com/gildedrose/ApprovalTest.java
+++ b/Java/src/test/java/com/gildedrose/ApprovalTest.java
@@ -1,0 +1,28 @@
+package com.gildedrose;
+
+import java.io.ByteArrayInputStream;
+import java.io.ByteArrayOutputStream;
+import java.io.PrintStream;
+
+import org.approvaltests.Approvals;
+import org.approvaltests.reporters.DiffReporter;
+import org.approvaltests.reporters.UseReporter;
+import org.junit.jupiter.api.Test;
+
+@UseReporter(DiffReporter.class)
+public class ApprovalTest {
+
+	@Test
+	public void thirtyDays() {
+
+		ByteArrayOutputStream fakeoutput = new ByteArrayOutputStream();
+		System.setOut(new PrintStream(fakeoutput));
+		System.setIn(new ByteArrayInputStream("a\n".getBytes()));
+
+		Program.main();
+		String output = fakeoutput.toString();
+
+		Approvals.verify(output);
+	}
+
+}


### PR DESCRIPTION
The csharp directory contains approvaltests which enables a quick introduction to the processing of the kata. The java directory, however, lacks approvaltests.
This PR contains the java porting of the csharp main program as well as the approvaltest, in content 1:1 according to the csharp variant as well as the necessary entry in the pom.xml so that the starting position is the same for both java and csharp. 