### PR TITLE
Replace ApprovalTests by Verify.Xunit

### DIFF
--- a/csharpcore/GildedRoseTests/ApprovalTest.cs
+++ b/csharpcore/GildedRoseTests/ApprovalTest.cs
@@ -1,18 +1,22 @@
-﻿using Xunit;
+﻿
+using GildedRoseKata;
+
 using System;
 using System.IO;
 using System.Text;
-using ApprovalTests;
-using ApprovalTests.Reporters;
-using GildedRoseKata;
+using System.Threading.Tasks;
+
+using VerifyXunit;
+
+using Xunit;
 
 namespace GildedRoseTests
 {
-    [UseReporter(typeof(DiffReporter))]
+    [UsesVerify]
     public class ApprovalTest
     {
         [Fact]
-        public void ThirtyDays()
+        public Task ThirtyDays()
         {
             var fakeoutput = new StringBuilder();
             Console.SetOut(new StringWriter(fakeoutput));
@@ -21,7 +25,7 @@ namespace GildedRoseTests
             Program.Main(new string[] { });
             var output = fakeoutput.ToString();
 
-            Approvals.Verify(output);
+            return Verifier.Verify(output);
         }
     }
 }

--- a/csharpcore/GildedRoseTests/GildedRoseTests.csproj
+++ b/csharpcore/GildedRoseTests/GildedRoseTests.csproj
@@ -1,20 +1,19 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
 
-  <PropertyGroup>
-    <TargetFramework>net6.0</TargetFramework>
-    <IsPackable>false</IsPackable>
-  </PropertyGroup>
+    <PropertyGroup>
+        <TargetFramework>net6.0</TargetFramework>
+        <IsPackable>false</IsPackable>
+    </PropertyGroup>
+    <ItemGroup>
+        <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.0.0" />
+        <PackageReference Include="Verify.Xunit" Version="14.11.4" />
+        <PackageReference Include="xunit" Version="2.4.1" />
+        <PackageReference Include="xunit.runner.visualstudio" Version="2.4.3" />
+        <PackageReference Include="coverlet.collector" Version="3.1.0" />
+    </ItemGroup>
 
-  <ItemGroup>
-    <PackageReference Include="ApprovalTests" Version="5.7.1" />
-    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.0.0" />
-    <PackageReference Include="xunit" Version="2.4.1" />
-    <PackageReference Include="xunit.runner.visualstudio" Version="2.4.3" />
-    <PackageReference Include="coverlet.collector" Version="3.1.0" />
-  </ItemGroup>
-
-  <ItemGroup>
-    <ProjectReference Include="..\GildedRose\GildedRose.csproj" />
-  </ItemGroup>
+    <ItemGroup>
+        <ProjectReference Include="..\GildedRose\GildedRose.csproj" />
+    </ItemGroup>
 
 </Project>


### PR DESCRIPTION
Visual Studio live unit tests line coverage doesn't work properly with ApprovalTests 
![VS Live Unit tests with ApprovalsTests](https://user-images.githubusercontent.com/9041103/147413584-54deca8b-577c-4f61-99b9-99c3328fd61e.png)

because of an error during test execution.
![ApprovalTests error message](https://user-images.githubusercontent.com/9041103/147413592-069b8b5a-a837-4648-8697-821400c12332.png)

By replacing ApprovalTests with Verify.Xunit line coverage is fixed so it's possible to use it as guide to remove useless line during refactoring.
![VS Live Unit tests with Verify](https://user-images.githubusercontent.com/9041103/147413588-2c1b825f-e6d7-495f-94b1-bb76c91b1665.png)

