### PR TITLE
Indent nested points to improve readability

### DIFF
--- a/GildedRoseRequirements.txt
+++ b/GildedRoseRequirements.txt
@@ -21,8 +21,8 @@ Pretty simple, right? Well this is where it gets interesting:
 	- The Quality of an item is never more than 50
 	- "Sulfuras", being a legendary item, never has to be sold or decreases in Quality
 	- "Backstage passes", like aged brie, increases in Quality as its SellIn value approaches;
-	Quality increases by 2 when there are 10 days or less and by 3 when there are 5 days or less but
-	Quality drops to 0 after the concert
+		- Quality increases by 2 when there are 10 days or less and by 3 when there are 5 days or less but
+		- Quality drops to 0 after the concert
 
 We have recently signed a supplier of conjured items. This requires an update to our system:
 


### PR DESCRIPTION
We routinely use the GildedRose challenge at my company and we have found on numerous occasions that the lack of indentation of these two statements makes it unclear that they relate to the "Backstage passes" criteria. By indenting them it should make it much clearer.