### PR TITLE
Update level: max in phpstan.neon

### DIFF
--- a/php/phpstan.neon
+++ b/php/phpstan.neon
@@ -8,8 +8,7 @@ parameters:
         - tests
         - fixtures
 
-    # The level 8 is the highest level
-    level: 8
+    level: max
 
     checkGenericClassInNonGenericObjectType: false
 


### PR DESCRIPTION
## 📚 Description

You can use max as an alias for the max level, which is the 9

> **Note**: See: https://github.com/phpstan/phpstan-src/blob/1.9.x/conf/config.levelmax.neon