### PR TITLE
Fix Item parametric type

### DIFF
--- a/julia/gilded_rose.jl
+++ b/julia/gilded_rose.jl
@@ -1,6 +1,6 @@
 import Base
 
-mutable struct Item{T<:Real}
+mutable struct Item{T<:Integer}
     name::String
     sellin::T
     quality::T


### PR DESCRIPTION
Realised I should have made the Item struct use ints instead of reals, so just a fix for that.