### PR TITLE
Make rust loop worse to make it closer to the original

### DIFF
--- a/rust/src/gildedrose.rs
+++ b/rust/src/gildedrose.rs
@@ -31,52 +31,52 @@ impl GildedRose {
     }
 
     pub fn update_quality(&mut self) {
-        for item in &mut self.items {
-            if item.name != "Aged Brie" && item.name != "Backstage passes to a TAFKAL80ETC concert"
+        for i in 0..self.items.len() {
+            if self.items[i].name != "Aged Brie" && self.items[i].name != "Backstage passes to a TAFKAL80ETC concert"
             {
-                if item.quality > 0 {
-                    if item.name != "Sulfuras, Hand of Ragnaros" {
-                        item.quality = item.quality - 1;
+                if self.items[i].quality > 0 {
+                    if self.items[i].name != "Sulfuras, Hand of Ragnaros" {
+                        self.items[i].quality = self.items[i].quality - 1;
                     }
                 }
             } else {
-                if item.quality < 50 {
-                    item.quality = item.quality + 1;
+                if self.items[i].quality < 50 {
+                    self.items[i].quality = self.items[i].quality + 1;
 
-                    if item.name == "Backstage passes to a TAFKAL80ETC concert" {
-                        if item.sell_in < 11 {
-                            if item.quality < 50 {
-                                item.quality = item.quality + 1;
+                    if self.items[i].name == "Backstage passes to a TAFKAL80ETC concert" {
+                        if self.items[i].sell_in < 11 {
+                            if self.items[i].quality < 50 {
+                                self.items[i].quality = self.items[i].quality + 1;
                             }
                         }
 
-                        if item.sell_in < 6 {
-                            if item.quality < 50 {
-                                item.quality = item.quality + 1;
+                        if self.items[i].sell_in < 6 {
+                            if self.items[i].quality < 50 {
+                                self.items[i].quality = self.items[i].quality + 1;
                             }
                         }
                     }
                 }
             }
 
-            if item.name != "Sulfuras, Hand of Ragnaros" {
-                item.sell_in = item.sell_in - 1;
+            if self.items[i].name != "Sulfuras, Hand of Ragnaros" {
+                self.items[i].sell_in = self.items[i].sell_in - 1;
             }
 
-            if item.sell_in < 0 {
-                if item.name != "Aged Brie" {
-                    if item.name != "Backstage passes to a TAFKAL80ETC concert" {
-                        if item.quality > 0 {
-                            if item.name != "Sulfuras, Hand of Ragnaros" {
-                                item.quality = item.quality - 1;
+            if self.items[i].sell_in < 0 {
+                if self.items[i].name != "Aged Brie" {
+                    if self.items[i].name != "Backstage passes to a TAFKAL80ETC concert" {
+                        if self.items[i].quality > 0 {
+                            if self.items[i].name != "Sulfuras, Hand of Ragnaros" {
+                                self.items[i].quality = self.items[i].quality - 1;
                             }
                         }
                     } else {
-                        item.quality = item.quality - item.quality;
+                        self.items[i].quality = self.items[i].quality - self.items[i].quality;
                     }
                 } else {
-                    if item.quality < 50 {
-                        item.quality = item.quality + 1;
+                    if self.items[i].quality < 50 {
+                        self.items[i].quality = self.items[i].quality + 1;
                     }
                 }
             }


### PR DESCRIPTION
The previous rust code uses a for loop that already loops over the items to update directly.
This makes the code worse and closer to the original by looping over indices instead and getting the item by index every time.