### PR TITLE
Fix bug in requirements

### DIFF
--- a/GildedRoseRequirements.txt
+++ b/GildedRoseRequirements.txt
@@ -19,7 +19,7 @@ Pretty simple, right? Well this is where it gets interesting:
 	- The Quality of an item is never negative
 	- "Aged Brie" actually increases in Quality the older it gets
 	- The Quality of an item is never more than 50
-	- "Sulfuras", being a legendary item, never has to be sold or decreases in Quality
+	- "Sulfuras, Hand of Ragnaros", being a legendary item, never has to be sold or decreases in Quality
 	- "Backstage passes", like aged brie, increases in Quality as its SellIn value approaches;
 	Quality increases by 2 when there are 10 days or less and by 3 when there are 5 days or less but
 	Quality drops to 0 after the concert
@@ -34,5 +34,5 @@ goblin in the corner who will insta-rage and one-shot you as he doesn't believe 
 ownership (you can make the UpdateQuality method and Items property static if you like, we'll cover
 for you).
 
-Just for clarification, an item can never have its Quality increase above 50, however "Sulfuras" is a
+Just for clarification, an item can never have its Quality increase above 50, however "Sulfuras, Hand of Ragnaros" is a
 legendary item and as such its Quality is 80 and it never alters.


### PR DESCRIPTION
Requirements says "Sulfuras" item can never be sold, while in the codebase  "Sulfuras, Hand of Ragnaros" name is used everywhere.