### PR TITLE
Make Julia compatible with texttests

### DIFF
--- a/julia/gilded_rose.jl
+++ b/julia/gilded_rose.jl
@@ -78,12 +78,13 @@ function main(; days::Int64=2)
         Item("Backstage passes to a TAFKAL80ETC concert", 5, 49),
         Item("Conjured Mana Cake", 3, 6),
     ]
-    for day in 1:days
+    for day in 0:days
         println("-------- day $day --------")
-        println("name, sellin, quality")
+        println("name, sellIn, quality")
         for item in items
             println(item)
         end
+        println()
         update_quality!(GildedRose(items))
     end
 end

--- a/julia/texttest_fixture.jl
+++ b/julia/texttest_fixture.jl
@@ -1,0 +1,9 @@
+include("gilded_rose.jl")
+
+if length(ARGS) > 0
+    days = parse(Int64, ARGS[1])
+else
+    days = 2
+end
+
+main(days=days)

--- a/texttests/config.gr
+++ b/texttests/config.gr
@@ -31,4 +31,8 @@ diff_program:meld
 #executable:${TEXTTEST_HOME}/TypeScript/test/golden-master-text-test.js
 #interpreter:node
 
+# Settings for the Julia version
+#executable:${TEXTTEST_HOME}/julia/texttest_fixture.jl
+#interpreter:julia
+
 filename_convention_scheme:standard


### PR DESCRIPTION
This makes the output of the Julia main function match what's expected by texttest, and adds (commented out) configuration for Julia to config.gr.