### PR TITLE
Add pr template and check

### DIFF
--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -1,0 +1,7 @@
+# READ ME BEFORE SUBMITTING A PR
+
+Please do not submit a PR with your solution to the Gilded Rose Kata. This repo is intended to be used as a starting point for the kata.
+
+- [ ] I acknowledge that this PR is not a solution to the Gilded Rose Kata, but an improvement to the template.
+
+## Please provide your PR description below this line

--- a/.github/workflows/pr-validation.yml
+++ b/.github/workflows/pr-validation.yml
@@ -1,0 +1,34 @@
+name: "PR Tasks Completed Check"
+on:
+  pull_request:
+    types: opened
+
+jobs:
+  task-check:
+    runs-on: ubuntu-latest
+    permissions:
+      issues: write
+      pull-requests: write
+    steps:
+      - name: Comment if checkmark is missing
+        if: ${{ !contains(github.event.pull_request.body, '[X] I acknowledge') }}
+        uses: actions/github-script@v6
+        with:
+          script: |
+            github.rest.issues.createComment({
+            issue_number: context.issue.number,
+            owner: context.repo.owner,
+            repo: context.repo.repo,
+            body: "Please don't submit a PR containing Kata solutions. If you are adding an improvement to the Katas repo, please resubmit this PR and check the `[X]` box in the PR template."
+            })
+      - name: Close PR if checkmark is missing
+        if: ${{ !contains(github.event.pull_request.body, '[X] I acknowledge') }}
+        uses: actions/github-script@v6
+        with:
+          script: |
+            github.rest.pulls.update({
+            pull_number: context.issue.number,
+            owner: context.repo.owner,
+            repo: context.repo.repo,
+            state: 'closed'
+            })


### PR DESCRIPTION
Hi @emilybache!

I have noticed that a large amount of PRs with kata solutions are submitted. I imagine it mostly happens because PRs created in a fork default to targeting the base repository. 

This PR adds a PR template and a workflow that automatically closes PR's that do not `[X]` the acknowledgement. It should help reduce PR maintenance work.

This is what a rejection would look like:
<img width="925" alt="image" src="https://github.com/emilybache/GildedRose-Refactoring-Kata/assets/657289/82a1f954-bd75-4021-9c76-4e9a58aef04a">
 

However, as I am writing this I realise that the PR template and associated workflow would run on forked repos as well. The job that adds a comment and closes the PR can easily be targeted to this specific repo with an `if: github.event.repository == emilybacke/GildedRose-Refactoring-Kata`, but the template and the checkmark would be confusing to encounter after making your own fork of the project. 

A smiliar solution that avoids the PR template could be to auto-close all PRs with a comment asking people to re-open their PR if it was not made by accident. 

Let me know your thoughts. I'm submitting this as a draft, and would be happy to modify it to fit whatever solution you prefer.