### PR TITLE
Update texttest expectation and fixtures to match spec

### DIFF
--- a/Ada/ThirtyDays.txt
+++ b/Ada/ThirtyDays.txt
@@ -9,7 +9,7 @@ Sulfuras, Hand of Ragnaros, -1, 80
 Backstage passes to a TAFKAL80ETC concert, 15, 20
 Backstage passes to a TAFKAL80ETC concert, 10, 49
 Backstage passes to a TAFKAL80ETC concert, 5, 49
-Conjured Mana Cake, 3, 6
+Conjured Mana Cake, 3, 10
 
 -------- day 1 --------
 name, sellIn, quality
@@ -21,7 +21,7 @@ Sulfuras, Hand of Ragnaros, -1, 80
 Backstage passes to a TAFKAL80ETC concert, 14, 21
 Backstage passes to a TAFKAL80ETC concert, 9, 50
 Backstage passes to a TAFKAL80ETC concert, 4, 50
-Conjured Mana Cake, 2, 5
+Conjured Mana Cake, 2, 8
 
 -------- day 2 --------
 name, sellIn, quality
@@ -33,7 +33,7 @@ Sulfuras, Hand of Ragnaros, -1, 80
 Backstage passes to a TAFKAL80ETC concert, 13, 22
 Backstage passes to a TAFKAL80ETC concert, 8, 50
 Backstage passes to a TAFKAL80ETC concert, 3, 50
-Conjured Mana Cake, 1, 4
+Conjured Mana Cake, 1, 6
 
 -------- day 3 --------
 name, sellIn, quality
@@ -45,7 +45,7 @@ Sulfuras, Hand of Ragnaros, -1, 80
 Backstage passes to a TAFKAL80ETC concert, 12, 23
 Backstage passes to a TAFKAL80ETC concert, 7, 50
 Backstage passes to a TAFKAL80ETC concert, 2, 50
-Conjured Mana Cake, 0, 3
+Conjured Mana Cake, 0, 4
 
 -------- day 4 --------
 name, sellIn, quality
@@ -57,7 +57,7 @@ Sulfuras, Hand of Ragnaros, -1, 80
 Backstage passes to a TAFKAL80ETC concert, 11, 24
 Backstage passes to a TAFKAL80ETC concert, 6, 50
 Backstage passes to a TAFKAL80ETC concert, 1, 50
-Conjured Mana Cake, -1, 1
+Conjured Mana Cake, -1, 0
 
 -------- day 5 --------
 name, sellIn, quality

--- a/Ada/program.adb
+++ b/Ada/program.adb
@@ -49,7 +49,7 @@ begin
   Things.Append(New_Item =>
     (Name => To_Unbounded_String("Conjured Mana Cake"),
      Sell_In => 3,
-     Quality => 6));
+     Quality => 10));
 
 
   declare

--- a/C/GildedRoseTextTests.c
+++ b/C/GildedRoseTextTests.c
@@ -23,7 +23,7 @@ int main()
     init_item(items + last++, "Backstage passes to a TAFKAL80ETC concert", 10, 49);
     init_item(items + last++, "Backstage passes to a TAFKAL80ETC concert", 5, 49);
     // this Conjured item doesn't yet work properly
-    init_item(items + last++, "Conjured Mana Cake", 3, 6);
+    init_item(items + last++, "Conjured Mana Cake", 3, 10);
     
     puts("OMGHAI!");
 

--- a/C/GildedRoseUnitTests.cc
+++ b/C/GildedRoseUnitTests.cc
@@ -32,7 +32,7 @@ void example()
     init_item(items + last++, "Elixir of the Mongoose", 5, 7);
     init_item(items + last++, "Sulfuras, Hand of Ragnaros", 0, 80);
     init_item(items + last++, "Backstage passes to a TAFKAL80ETC concert", 15, 20);
-    init_item(items + last++, "Conjured Mana Cake", 3, 6);
+    init_item(items + last++, "Conjured Mana Cake", 3, 10);
     update_quality(items, last);
 }
 

--- a/Groovy/src/test/groovy/com/gildedrose/TexttestFixture.groovy
+++ b/Groovy/src/test/groovy/com/gildedrose/TexttestFixture.groovy
@@ -12,7 +12,7 @@ Item[] items = [
         new Item("Backstage passes to a TAFKAL80ETC concert", 10, 49),
         new Item("Backstage passes to a TAFKAL80ETC concert", 5, 49),
         // this conjured item does not work properly yet
-        new Item("Conjured Mana Cake", 3, 6)] as Item[]
+        new Item("Conjured Mana Cake", 3, 10)] as Item[]
 
 GildedRose app = new GildedRose(items)
 

--- a/Java-Approvals/src/main/java/com/gildedrose/Program.java
+++ b/Java-Approvals/src/main/java/com/gildedrose/Program.java
@@ -15,7 +15,7 @@ public class Program {
 				new Item("Backstage passes to a TAFKAL80ETC concert", 10, 49),
 				new Item("Backstage passes to a TAFKAL80ETC concert", 5, 49),
 				// this conjured item does not work properly yet
-				new Item("Conjured Mana Cake", 3, 6) };
+				new Item("Conjured Mana Cake", 3, 10) };
 
 		GildedRose app = new GildedRose(items);
 

--- a/Java-Cucumber/src/main/java/com/gildedrose/TexttestFixture.java
+++ b/Java-Cucumber/src/main/java/com/gildedrose/TexttestFixture.java
@@ -14,7 +14,7 @@ public class TexttestFixture {
                 new Item("Backstage passes to a TAFKAL80ETC concert", 10, 49),
                 new Item("Backstage passes to a TAFKAL80ETC concert", 5, 49),
                 // this conjured item does not work properly yet
-                new Item("Conjured Mana Cake", 3, 6) };
+                new Item("Conjured Mana Cake", 3, 10) };
 
         GildedRose app = new GildedRose(items);
 

--- a/Java-Spock/src/main/java/com/gildedrose/TexttestFixture.java
+++ b/Java-Spock/src/main/java/com/gildedrose/TexttestFixture.java
@@ -14,7 +14,7 @@ public class TexttestFixture {
                 new Item("Backstage passes to a TAFKAL80ETC concert", 10, 49),
                 new Item("Backstage passes to a TAFKAL80ETC concert", 5, 49),
                 // this conjured item does not work properly yet
-                new Item("Conjured Mana Cake", 3, 6) };
+                new Item("Conjured Mana Cake", 3, 10) };
 
         GildedRose app = new GildedRose(items);
 

--- a/Java/src/test/java/com/gildedrose/TexttestFixture.java
+++ b/Java/src/test/java/com/gildedrose/TexttestFixture.java
@@ -14,7 +14,7 @@ public class TexttestFixture {
                 new Item("Backstage passes to a TAFKAL80ETC concert", 10, 49),
                 new Item("Backstage passes to a TAFKAL80ETC concert", 5, 49),
                 // this conjured item does not work properly yet
-                new Item("Conjured Mana Cake", 3, 6) };
+                new Item("Conjured Mana Cake", 3, 10) };
 
         GildedRose app = new GildedRose(items);
 

--- a/Kotlin/src/test/kotlin/com/gildedrose/TexttestFixture.kt
+++ b/Kotlin/src/test/kotlin/com/gildedrose/TexttestFixture.kt
@@ -13,7 +13,7 @@ fun main(args: Array<String>) {
             Item("Backstage passes to a TAFKAL80ETC concert", 10, 49),
             Item("Backstage passes to a TAFKAL80ETC concert", 5, 49),
             // this conjured item does not work properly yet
-            Item("Conjured Mana Cake", 3, 6))
+            Item("Conjured Mana Cake", 3, 10))
 
     val app = GildedRose(items)
 

--- a/R/texttest_fixture.R
+++ b/R/texttest_fixture.R
@@ -14,7 +14,7 @@ items <- list(
   item('Backstage passes to a TAFKAL80ETC concert', 10, 49),
   item('Backstage passes to a TAFKAL80ETC concert', 5, 49),
   # This Conjured item does not work properly yet
-  item('Conjured Mana Cake', 3, 6)
+  item('Conjured Mana Cake', 3, 10)
 )
 
 days <- 2

--- a/Smalltalk/GildedRose.st
+++ b/Smalltalk/GildedRose.st
@@ -108,7 +108,7 @@ runExamples
 		add: (Item new name: 'Backstage passes to a TAFKAL80ETC concert'; sellIn: 15; quality: 20; yourself);
 		add: (Item new name: 'Backstage passes to a TAFKAL80ETC concert'; sellIn: 10; quality: 49; yourself);
 		add: (Item new name: 'Backstage passes to a TAFKAL80ETC concert'; sellIn: 5; quality: 49; yourself);
-		add: (Item new name: 'Conjured Mana Cake'; sellIn: 3; quality: 6; yourself); "this conjured item does not work properly yet"
+		add: (Item new name: 'Conjured Mana Cake'; sellIn: 3; quality: 10; yourself); "this conjured item does not work properly yet"
 		yourself.
 
 	gildedRose := GildedRose new.

--- a/TypeScript/test/golden-master-text-test.ts
+++ b/TypeScript/test/golden-master-text-test.ts
@@ -10,7 +10,7 @@ const items = [
   new Item("Backstage passes to a TAFKAL80ETC concert", 10, 49),
   new Item("Backstage passes to a TAFKAL80ETC concert", 5, 49),
   // this conjured item does not work properly yet
-  new Item("Conjured Mana Cake", 3, 6)];
+  new Item("Conjured Mana Cake", 3, 10)];
 
 
 const gildedRose = new GildedRose(items);

--- a/abap/YY_PAO_GILDED_ROSE.abap
+++ b/abap/YY_PAO_GILDED_ROSE.abap
@@ -195,7 +195,7 @@ CLASS lth_texttest_fixture IMPLEMENTATION.
                         "This conjured item does not work properly yet
                         ( NEW #( iv_name    = |Conjured Mana Cake|
                                  iv_sell_in = 3
-                                 iv_quality = 6 ) ) ).
+                                 iv_quality = 10 ) ) ).
 
     DATA(lo_app) = NEW lcl_gilded_rose( it_items = lt_items ).
 

--- a/c99/GildedRoseTextTests.c
+++ b/c99/GildedRoseTextTests.c
@@ -23,7 +23,7 @@ int main()
     init_item(items + last++, "Backstage passes to a TAFKAL80ETC concert", 10, 49);
     init_item(items + last++, "Backstage passes to a TAFKAL80ETC concert", 5, 49);
     // this Conjured item doesn't yet work properly
-    init_item(items + last++, "Conjured Mana Cake", 3, 6);
+    init_item(items + last++, "Conjured Mana Cake", 3, 10);
     
     puts("OMGHAI!");
 

--- a/clojure/src/gilded/main.clj
+++ b/clojure/src/gilded/main.clj
@@ -19,7 +19,7 @@
    {:name "Backstage passes to a TAFKAL80ETC concert", :quality 20, :sell-in 15}
    {:name "Backstage passes to a TAFKAL80ETC concert", :quality 49, :sell-in 10}
    {:name "Backstage passes to a TAFKAL80ETC concert", :quality 49, :sell-in 5}
-   {:name "Conjured Mana Cake", :quality 6, :sell-in 3}])
+   {:name "Conjured Mana Cake", :quality 10, :sell-in 3}])
 
 (defn -main [& args]
   (let [n-days (if (nil? (first args))

--- a/common-lisp-parachute/source/gilded-rose.lisp
+++ b/common-lisp-parachute/source/gilded-rose.lisp
@@ -71,7 +71,7 @@
                          ("Backstage passes to a TAFKAL80ETC concert" 10 49)
                          ("Backstage passes to a TAFKAL80ETC concert"  5 49)
                          ;; this conjured item does not work properly yet
-                         ("Conjured Mana Cake"                         3  6)))
+                         ("Conjured Mana Cake"                         3  10)))
          (items (loop :for (name sell-in quality) :in descriptions
                       :collect (make-instance 'item
                                               :name name

--- a/commonlisp/gilded-rose-functional.lisp
+++ b/commonlisp/gilded-rose-functional.lisp
@@ -115,7 +115,7 @@
                          ("Backstage passes to a TAFKAL80ETC concert" 10 49)
                          ("Backstage passes to a TAFKAL80ETC concert"  5 49)
                          ;; this conjured item does not work properly yet
-                         ("Conjured Mana Cake"                         3  6)))
+                         ("Conjured Mana Cake"                         3  10)))
          (items (loop :for (name sell-in quality) :in descriptions
                       :collect (make-item :name name
                                           :sell-in sell-in

--- a/commonlisp/gilded-rose.lisp
+++ b/commonlisp/gilded-rose.lisp
@@ -112,7 +112,7 @@
                          ("Backstage passes to a TAFKAL80ETC concert" 10 49)
                          ("Backstage passes to a TAFKAL80ETC concert"  5 49)
                          ;; this conjured item does not work properly yet
-                         ("Conjured Mana Cake"                         3  6)))
+                         ("Conjured Mana Cake"                         3  10)))
          (items (loop :for (name sell-in quality) :in descriptions
                       :collect (make-instance 'item
                                               :name name

--- a/cpp/test/cpp_texttest/GildedRoseTextTests.cc
+++ b/cpp/test/cpp_texttest/GildedRoseTextTests.cc
@@ -20,7 +20,7 @@ int main()
     items.push_back({"Backstage passes to a TAFKAL80ETC concert", 5, 49});
 
     // this Conjured item doesn't yet work properly
-    items.push_back({"Conjured Mana Cake", 3, 6});
+    items.push_back({"Conjured Mana Cake", 3, 10});
 
 	std::cout << "OMGHAI!" << std::endl;
 

--- a/csharp/Program.cs
+++ b/csharp/Program.cs
@@ -34,7 +34,7 @@ namespace csharp
                     Quality = 49
                 },
 				// this conjured item does not work properly yet
-				new Item {Name = "Conjured Mana Cake", SellIn = 3, Quality = 6}
+				new Item {Name = "Conjured Mana Cake", SellIn = 3, Quality = 10}
             };
 
             var app = new GildedRose(Items);

--- a/csharpcore-Verify.xunit/GildedRose/Program.cs
+++ b/csharpcore-Verify.xunit/GildedRose/Program.cs
@@ -34,7 +34,7 @@ namespace GildedRoseKata
                     Quality = 49
                 },
 				// this conjured item does not work properly yet
-				new Item {Name = "Conjured Mana Cake", SellIn = 3, Quality = 6}
+				new Item {Name = "Conjured Mana Cake", SellIn = 3, Quality = 10}
             };
 
             var app = new GildedRose(Items);

--- a/csharpcore/GildedRoseTests/TextTestFixture.cs
+++ b/csharpcore/GildedRoseTests/TextTestFixture.cs
@@ -35,7 +35,7 @@ public static class TextTestFixture
                 Quality = 49
             },
             // this conjured item does not work properly yet
-            new Item {Name = "Conjured Mana Cake", SellIn = 3, Quality = 6}
+            new Item {Name = "Conjured Mana Cake", SellIn = 3, Quality = 10}
         };
 
         var app = new GildedRose(items);

--- a/d/src/GildedRoseTextTests.d
+++ b/d/src/GildedRoseTextTests.d
@@ -14,7 +14,7 @@ int main()
         Item("Backstage passes to a TAFKAL80ETC concert", 10, 49),
         Item("Backstage passes to a TAFKAL80ETC concert", 5, 49),
         // this Conjured item doesn't yet work properly
-        Item("Conjured Mana Cake", 3, 6),
+        Item("Conjured Mana Cake", 3, 10),
     ];
 
     auto app = new GildedRose(items);

--- a/d/test/GildedRoseUnitTests.d
+++ b/d/test/GildedRoseUnitTests.d
@@ -18,7 +18,7 @@ void example()
         Item("Elixir of the Mongoose", 5, 7),
         Item("Sulfuras, Hand of Ragnaros", 0, 80),
         Item("Backstage passes to a TAFKAL80ETC concert", 15, 20),
-        Item("Conjured Mana Cake", 3, 6),
+        Item("Conjured Mana Cake", 3, 10),
     ];
     auto app = new GildedRose(items);
     app.updateQuality;

--- a/dart/bin/main.dart
+++ b/dart/bin/main.dart
@@ -13,7 +13,7 @@ main(List<String> args) {
     new Item("Backstage passes to a TAFKAL80ETC concert", 10, 49),
     new Item("Backstage passes to a TAFKAL80ETC concert", 5, 49),
     // this conjured item does not work properly yet
-    new Item("Conjured Mana Cake", 3, 6)
+    new Item("Conjured Mana Cake", 3, 10)
   ];
 
   GildedRose app = new GildedRose(items);

--- a/erlang/src/main.erl
+++ b/erlang/src/main.erl
@@ -13,7 +13,7 @@
   #item{name = "Backstage passes to a TAFKAL80ETC concert", sell_in = 15, quality = 20},
   #item{name = "Backstage passes to a TAFKAL80ETC concert", sell_in = 10, quality = 49},
   #item{name = "Backstage passes to a TAFKAL80ETC concert", sell_in = 5, quality = 49},
-  #item{name = "Conjured Mana Cake", sell_in = 3, quality = 6}
+  #item{name = "Conjured Mana Cake", sell_in = 3, quality = 10}
 ]).
 
 main([Days]) ->

--- a/fortran/test/GildedRose_text_test.f90
+++ b/fortran/test/GildedRose_text_test.f90
@@ -31,7 +31,7 @@ program GildedRose_text_test
   call init_item(items(last), "Backstage passes to a TAFKAL80ETC concert", 5, 49)
   ! this Conjured item doesn't yet work properly
   last=last+1
-  call init_item(items(last), "Conjured Mana Cake", 3, 6)
+  call init_item(items(last), "Conjured Mana Cake", 3, 10)
 
   write(*,*) "OMGHAI!"
 

--- a/fsharp-core/GildedRose.ApprovalTests/GildedRoseTest.ApprovalTest.ThirtyDays.received.txt
+++ b/fsharp-core/GildedRose.ApprovalTests/GildedRoseTest.ApprovalTest.ThirtyDays.received.txt
@@ -9,7 +9,7 @@ Sulfuras, Hand of Ragnaros, -1, 80
 Backstage passes to a TAFKAL80ETC concert, 15, 20
 Backstage passes to a TAFKAL80ETC concert, 10, 49
 Backstage passes to a TAFKAL80ETC concert, 5, 49
-Conjured Mana Cake, 3, 6
+Conjured Mana Cake, 3, 10
 
 -------- day 1 --------
 name, sellIn, quality
@@ -21,7 +21,7 @@ Sulfuras, Hand of Ragnaros, -1, 80
 Backstage passes to a TAFKAL80ETC concert, 14, 21
 Backstage passes to a TAFKAL80ETC concert, 9, 50
 Backstage passes to a TAFKAL80ETC concert, 4, 50
-Conjured Mana Cake, 2, 5
+Conjured Mana Cake, 2, 8
 
 -------- day 2 --------
 name, sellIn, quality
@@ -33,7 +33,7 @@ Sulfuras, Hand of Ragnaros, -1, 80
 Backstage passes to a TAFKAL80ETC concert, 13, 22
 Backstage passes to a TAFKAL80ETC concert, 8, 50
 Backstage passes to a TAFKAL80ETC concert, 3, 50
-Conjured Mana Cake, 1, 4
+Conjured Mana Cake, 1, 6
 
 -------- day 3 --------
 name, sellIn, quality
@@ -45,7 +45,7 @@ Sulfuras, Hand of Ragnaros, -1, 80
 Backstage passes to a TAFKAL80ETC concert, 12, 23
 Backstage passes to a TAFKAL80ETC concert, 7, 50
 Backstage passes to a TAFKAL80ETC concert, 2, 50
-Conjured Mana Cake, 0, 3
+Conjured Mana Cake, 0, 4
 
 -------- day 4 --------
 name, sellIn, quality
@@ -57,7 +57,7 @@ Sulfuras, Hand of Ragnaros, -1, 80
 Backstage passes to a TAFKAL80ETC concert, 11, 24
 Backstage passes to a TAFKAL80ETC concert, 6, 50
 Backstage passes to a TAFKAL80ETC concert, 1, 50
-Conjured Mana Cake, -1, 1
+Conjured Mana Cake, -1, 0
 
 -------- day 5 --------
 name, sellIn, quality

--- a/fsharp-core/GildedRose/Program.fs
+++ b/fsharp-core/GildedRose/Program.fs
@@ -52,7 +52,7 @@ module Program =
         Items.Add({Name = "Backstage passes to a TAFKAL80ETC concert"; SellIn = 15; Quality = 20})
         Items.Add({Name = "Backstage passes to a TAFKAL80ETC concert"; SellIn = 10; Quality = 49})
         Items.Add({Name = "Backstage passes to a TAFKAL80ETC concert"; SellIn = 5; Quality = 49})
-        Items.Add({Name = "Conjured Mana Cake"; SellIn = 3; Quality = 6})
+        Items.Add({Name = "Conjured Mana Cake"; SellIn = 3; Quality = 10})
 
         let app = new GildedRose(Items)
         for i = 0 to 30 do

--- a/fsharp/GildedRose/GildedRose.fs
+++ b/fsharp/GildedRose/GildedRose.fs
@@ -50,7 +50,7 @@ let main argv =
     Items.Add({Name = "Backstage passes to a TAFKAL80ETC concert"; SellIn = 15; Quality = 20})
     Items.Add({Name = "Backstage passes to a TAFKAL80ETC concert"; SellIn = 10; Quality = 49})
     Items.Add({Name = "Backstage passes to a TAFKAL80ETC concert"; SellIn = 5; Quality = 49})
-    Items.Add({Name = "Conjured Mana Cake"; SellIn = 3; Quality = 6})
+    Items.Add({Name = "Conjured Mana Cake"; SellIn = 3; Quality = 10})
 
     let app = new GildedRose(Items)
     for i = 0 to 30 do

--- a/go/texttest_fixture.go
+++ b/go/texttest_fixture.go
@@ -20,7 +20,7 @@ func main() {
 		{"Backstage passes to a TAFKAL80ETC concert", 15, 20},
 		{"Backstage passes to a TAFKAL80ETC concert", 10, 49},
 		{"Backstage passes to a TAFKAL80ETC concert", 5, 49},
-		{"Conjured Mana Cake", 3, 6}, // <-- :O
+		{"Conjured Mana Cake", 3, 10}, // <-- :O
 	}
 
 	days := 2

--- a/haskell/src/Main.hs
+++ b/haskell/src/Main.hs
@@ -40,5 +40,5 @@ main = do
       , Item "Backstage passes to a TAFKAL80ETC concert"  10  49
       , Item "Backstage passes to a TAFKAL80ETC concert"   5  49
       -- this conjured item does not work properly yet
-      , Item "Conjured Mana Cake"                          3   6
+      , Item "Conjured Mana Cake"                          3   10
       ]

--- a/janet/test/texttest.janet
+++ b/janet/test/texttest.janet
@@ -9,7 +9,7 @@
     (shop/item "Backstage passes to a TAFKAL80ETC concert" 20 15)
     (shop/item "Backstage passes to a TAFKAL80ETC concert" 49 10)
     (shop/item "Backstage passes to a TAFKAL80ETC concert" 49 5)
-    (shop/item "Conjured Mana Cake" 6 3)])
+    (shop/item "Conjured Mana Cake" 10 3)])
 
 # judge allows for snapshot testing of stdout, much like the texttest tool. 
 # So something like the following would create a janet-native test of the output of shop/run:

--- a/jq/texttest_fixture.jq
+++ b/jq/texttest_fixture.jq
@@ -9,7 +9,7 @@
         { name: "Backstage passes to a TAFKAL80ETC concert", sell_in: 15, quality: 20 },
         { name: "Backstage passes to a TAFKAL80ETC concert", sell_in: 10, quality: 49 },
         { name: "Backstage passes to a TAFKAL80ETC concert", sell_in: 5, quality: 49 },
-        { name: "Conjured Mana Cake", sell_in: 3, quality: 6}  # <-- :O
+        { name: "Conjured Mana Cake", sell_in: 3, quality: 10}  # <-- :O
     ] |
     { items: ., day: 0 } |
     recurse(.day += 1 | .items = (.items | update_quality); .day < ($ARGS.named.days // 2 | tonumber)) |

--- a/js-jasmine/spec/texttest_fixture.js
+++ b/js-jasmine/spec/texttest_fixture.js
@@ -12,7 +12,7 @@ const items = [
   new Item("Backstage passes to a TAFKAL80ETC concert", 5, 49),
 
   // This Conjured item does not work properly yet
-  new Item("Conjured Mana Cake", 3, 6),
+  new Item("Conjured Mana Cake", 3, 10),
 ];
 
 const days = Number(process.argv[2]) || 2;

--- a/js-jest/test/texttest_fixture.js
+++ b/js-jest/test/texttest_fixture.js
@@ -12,7 +12,7 @@ const items = [
   new Item("Backstage passes to a TAFKAL80ETC concert", 5, 49),
 
   // This Conjured item does not work properly yet
-  new Item("Conjured Mana Cake", 3, 6),
+  new Item("Conjured Mana Cake", 3, 10),
 ];
 
 const days = Number(process.argv[2]) || 2;

--- a/js-mocha/test/texttest_fixture.js
+++ b/js-mocha/test/texttest_fixture.js
@@ -12,7 +12,7 @@ const items = [
   new Item("Backstage passes to a TAFKAL80ETC concert", 5, 49),
 
   // This Conjured item does not work properly yet
-  new Item("Conjured Mana Cake", 3, 6),
+  new Item("Conjured Mana Cake", 3, 10),
 ];
 
 const days = Number(process.argv[2]) || 2;

--- a/julia/gilded_rose.jl
+++ b/julia/gilded_rose.jl
@@ -76,7 +76,7 @@ function main(; days::Int64=2)
         Item("Backstage passes to a TAFKAL80ETC concert", 15, 20),
         Item("Backstage passes to a TAFKAL80ETC concert", 10, 49),
         Item("Backstage passes to a TAFKAL80ETC concert", 5, 49),
-        Item("Conjured Mana Cake", 3, 6),
+        Item("Conjured Mana Cake", 3, 10),
     ]
     for day in 0:days
         println("-------- day $day --------")

--- a/lfe/src/gilded-rose.lfe
+++ b/lfe/src/gilded-rose.lfe
@@ -123,7 +123,7 @@
                      (make-item name "Backstage passes to a TAFKAL80ETC concert" sellin 10 quality 49)
                      (make-item name "Backstage passes to a TAFKAL80ETC concert" sellin 5 quality 49)
                      ;; this conjured item does not work properly yet
-                     (make-item name "Conjured Mana Cake" sellin 3 quality 6))))
+                     (make-item name "Conjured Mana Cake" sellin 3 quality 10))))
 
     (lists:foldl (lambda (day gr)
                    (print-day day (gilded-rose-items gr))

--- a/pascal/TEXTTEST.PAS
+++ b/pascal/TEXTTEST.PAS
@@ -31,7 +31,7 @@ begin
     InitItem(Items.Elements^[Last], 'Backstage passes to a TAFKAL80ETC concert', 5, 49);
     Inc(Last);
     { this Conjured item doesn't yet work properly }
-    InitItem(Items.Elements^[Last], 'Conjured Mana Cake', 3, 6);
+    InitItem(Items.Elements^[Last], 'Conjured Mana Cake', 3, 10);
     Inc(Last);
     Items.Length := Last;
 

--- a/perl/texttest_fixture.pl
+++ b/perl/texttest_fixture.pl
@@ -51,7 +51,7 @@ my $items = [
     Item->new(    # This Conjured item does not work properly yet
         name    => 'Conjured Mana Cake',
         sell_in => 3,
-        quality => 6
+        quality => 10
     ),
 ];
 

--- a/perl6/texttest_fixture.p6
+++ b/perl6/texttest_fixture.p6
@@ -52,7 +52,7 @@ my @items = (
     Item.new(    # This Conjured item does not work properly yet
         name    => 'Conjured Mana Cake',
         sell_in => 3,
-        quality => 6
+        quality => 10
     ),
 );
 

--- a/php/fixtures/texttest_fixture.php
+++ b/php/fixtures/texttest_fixture.php
@@ -19,7 +19,7 @@ $items = [
     new Item('Backstage passes to a TAFKAL80ETC concert', 10, 49),
     new Item('Backstage passes to a TAFKAL80ETC concert', 5, 49),
     // this conjured item does not work properly yet
-    new Item('Conjured Mana Cake', 3, 6),
+    new Item('Conjured Mana Cake', 3, 10),
 ];
 
 $app = new GildedRose($items);

--- a/php/tests/approvals/ApprovalTest.testTestFixture.approved.txt
+++ b/php/tests/approvals/ApprovalTest.testTestFixture.approved.txt
@@ -9,7 +9,7 @@ Sulfuras, Hand of Ragnaros, -1, 80
 Backstage passes to a TAFKAL80ETC concert, 15, 20
 Backstage passes to a TAFKAL80ETC concert, 10, 49
 Backstage passes to a TAFKAL80ETC concert, 5, 49
-Conjured Mana Cake, 3, 6
+Conjured Mana Cake, 3, 10
 
 -------- day 1 --------
 name, sellIn, quality
@@ -21,7 +21,7 @@ Sulfuras, Hand of Ragnaros, -1, 80
 Backstage passes to a TAFKAL80ETC concert, 14, 21
 Backstage passes to a TAFKAL80ETC concert, 9, 50
 Backstage passes to a TAFKAL80ETC concert, 4, 50
-Conjured Mana Cake, 2, 5
+Conjured Mana Cake, 2, 8
 
 -------- day 2 --------
 name, sellIn, quality
@@ -33,7 +33,7 @@ Sulfuras, Hand of Ragnaros, -1, 80
 Backstage passes to a TAFKAL80ETC concert, 13, 22
 Backstage passes to a TAFKAL80ETC concert, 8, 50
 Backstage passes to a TAFKAL80ETC concert, 3, 50
-Conjured Mana Cake, 1, 4
+Conjured Mana Cake, 1, 6
 
 -------- day 3 --------
 name, sellIn, quality
@@ -45,7 +45,7 @@ Sulfuras, Hand of Ragnaros, -1, 80
 Backstage passes to a TAFKAL80ETC concert, 12, 23
 Backstage passes to a TAFKAL80ETC concert, 7, 50
 Backstage passes to a TAFKAL80ETC concert, 2, 50
-Conjured Mana Cake, 0, 3
+Conjured Mana Cake, 0, 4
 
 -------- day 4 --------
 name, sellIn, quality
@@ -57,7 +57,7 @@ Sulfuras, Hand of Ragnaros, -1, 80
 Backstage passes to a TAFKAL80ETC concert, 11, 24
 Backstage passes to a TAFKAL80ETC concert, 6, 50
 Backstage passes to a TAFKAL80ETC concert, 1, 50
-Conjured Mana Cake, -1, 1
+Conjured Mana Cake, -1, 0
 
 -------- day 5 --------
 name, sellIn, quality

--- a/plpgsql/pgunit/run_tests.sql
+++ b/plpgsql/pgunit/run_tests.sql
@@ -49,7 +49,7 @@ BEGIN
   CALL new_item('Backstage passes to a TAFKAL80ETC concert', 10, 49);
   CALL new_item('Backstage passes to a TAFKAL80ETC concert', 5, 49);
   -- this conjured item does not work properly yet ;
-  CALL new_item('Conjured Mana Cake', 3, 6);
+  CALL new_item('Conjured Mana Cake', 3, 10);
   days := 1;
 
   -- when
@@ -70,7 +70,7 @@ BEGIN
     'Backstage passes to a TAFKAL80ETC concert, 5, 49', 
     'Backstage passes to a TAFKAL80ETC concert, 10, 49',
     'Backstage passes to a TAFKAL80ETC concert, 15, 20',
-    'Conjured Mana Cake, 3, 6', 
+    'Conjured Mana Cake, 3, 10', 
     'Elixir of the Mongoose, 5, 7', 
     'Sulfuras, Hand of Ragnaros, -1, 80', 
     'Sulfuras, Hand of Ragnaros, 0, 80',
@@ -81,7 +81,7 @@ BEGIN
     'Backstage passes to a TAFKAL80ETC concert, 4, 50', 
     'Backstage passes to a TAFKAL80ETC concert, 9, 50', 
     'Backstage passes to a TAFKAL80ETC concert, 14, 21',
-    'Conjured Mana Cake, 2, 5', 
+    'Conjured Mana Cake, 2, 8', 
     'Elixir of the Mongoose, 4, 6', 
     'Sulfuras, Hand of Ragnaros, -1, 80', 
     'Sulfuras, Hand of Ragnaros, 0, 80'

--- a/plsql/texttest.pkb
+++ b/plsql/texttest.pkb
@@ -19,7 +19,7 @@ CREATE OR REPLACE PACKAGE BODY texttest IS
       new_item('Backstage passes to a TAFKAL80ETC concert', 10, 49);
       new_item('Backstage passes to a TAFKAL80ETC concert', 5, 49);
       -- this conjured item does not work properly yet ;
-      new_item('Conjured Mana Cake', 3, 6);
+      new_item('Conjured Mana Cake', 3, 10);
    END setup;
 
    PROCEDURE main_test IS
@@ -43,7 +43,7 @@ CREATE OR REPLACE PACKAGE BODY texttest IS
       put_line(v_expected, 'Backstage passes to a TAFKAL80ETC concert, 15, 20');
       put_line(v_expected, 'Backstage passes to a TAFKAL80ETC concert, 10, 49');
       put_line(v_expected, 'Backstage passes to a TAFKAL80ETC concert, 5, 49');
-      put_line(v_expected, 'Conjured Mana Cake, 3, 6');
+      put_line(v_expected, 'Conjured Mana Cake, 3, 10');
       put_line(v_expected, '-------- day 1 --------');
       put_line(v_expected, 'name, sellIn, quality');
       put_line(v_expected, '+5 Dexterity Vest, 9, 19');
@@ -54,7 +54,7 @@ CREATE OR REPLACE PACKAGE BODY texttest IS
       put_line(v_expected, 'Backstage passes to a TAFKAL80ETC concert, 14, 21');
       put_line(v_expected, 'Backstage passes to a TAFKAL80ETC concert, 9, 50');
       put_line(v_expected, 'Backstage passes to a TAFKAL80ETC concert, 4, 50');
-      put_line(v_expected, 'Conjured Mana Cake, 2, 5');
+      put_line(v_expected, 'Conjured Mana Cake, 2, 8');
 
       put_line(v_result, 'OMGHAI!');
       l_days := 2;

--- a/rescript/src/TextTest.bs.js
+++ b/rescript/src/TextTest.bs.js
@@ -20,7 +20,7 @@ var items = {
     GildedRose.Item.make("Backstage passes to a TAFKAL80ETC concert", 15, 20),
     GildedRose.Item.make("Backstage passes to a TAFKAL80ETC concert", 10, 49),
     GildedRose.Item.make("Backstage passes to a TAFKAL80ETC concert", 5, 49),
-    GildedRose.Item.make("Conjured Mana Cake", 3, 6)
+    GildedRose.Item.make("Conjured Mana Cake", 3, 10)
   ]
 };
 

--- a/rescript/src/TextTest.res
+++ b/rescript/src/TextTest.res
@@ -11,7 +11,7 @@ let items: ref<array<Item.t>> = ref([
   Item.make(~name="Backstage passes to a TAFKAL80ETC concert", ~sellIn=15, ~quality=20),
   Item.make(~name="Backstage passes to a TAFKAL80ETC concert", ~sellIn=10, ~quality=49),
   Item.make(~name="Backstage passes to a TAFKAL80ETC concert", ~sellIn=5, ~quality=49),
-  Item.make(~name="Conjured Mana Cake", ~sellIn=3, ~quality=6),
+  Item.make(~name="Conjured Mana Cake", ~sellIn=3, ~quality=10),
 ])
 
 let days = Node.Process.argv->Belt.Array.get(2)->Belt.Option.mapWithDefault(31, int_of_string)

--- a/ruby/texttest_fixture.rb
+++ b/ruby/texttest_fixture.rb
@@ -13,7 +13,7 @@ items = [
   Item.new(name="Backstage passes to a TAFKAL80ETC concert", sell_in=10, quality=49),
   Item.new(name="Backstage passes to a TAFKAL80ETC concert", sell_in=5, quality=49),
   # This Conjured item does not work properly yet
-  Item.new(name="Conjured Mana Cake", sell_in=3, quality=6), # <-- :O
+  Item.new(name="Conjured Mana Cake", sell_in=3, quality=10), # <-- :O
 ]
 
 days = 2

--- a/rust/src/main.rs
+++ b/rust/src/main.rs
@@ -13,7 +13,7 @@ fn main() {
         Item::new("Backstage passes to a TAFKAL80ETC concert", 10, 49),
         Item::new("Backstage passes to a TAFKAL80ETC concert", 5, 49),
         // this conjured item does not work properly yet
-        Item::new("Conjured Mana Cake", 3, 6),
+        Item::new("Conjured Mana Cake", 3, 10),
     ];
     let mut rose = GildedRose::new(items);
 

--- a/scala/src/test/scala/com/gildedrose/TexttestFixture.scala
+++ b/scala/src/test/scala/com/gildedrose/TexttestFixture.scala
@@ -12,7 +12,7 @@ object TexttestFixture {
       new Item("Backstage passes to a TAFKAL80ETC concert", 10, 49),
       new Item("Backstage passes to a TAFKAL80ETC concert", 5, 49),
       // this conjured item does not work properly yet
-      new Item("Conjured Mana Cake", 3, 6)
+      new Item("Conjured Mana Cake", 3, 10)
     )
     val app = new GildedRose(items)
     val days = if (args.length > 0) args(0).toInt + 1 else 2

--- a/scheme/texttest-fixture.scm
+++ b/scheme/texttest-fixture.scm
@@ -12,7 +12,7 @@
                    (make-item "Backstage passes to a TAFKAL80ETC concert" 10 49)
                    (make-item "Backstage passes to a TAFKAL80ETC concert" 5 49)
                    ;; this conjured item does not work properly yet
-                   (make-item "Conjured Mana Cake" 3 6)))
+                   (make-item "Conjured Mana Cake" 3 10)))
       (days  2))
 
     (define (loop day)

--- a/sql/test/data/load.sql
+++ b/sql/test/data/load.sql
@@ -10,6 +10,6 @@ INSERT INTO item (name, sellIn, quality) VALUES ('Backstage passes to a TAFKAL80
 INSERT INTO item (name, sellIn, quality) VALUES ('Backstage passes to a TAFKAL80ETC concert', 5, 49);
 
 -- this conjured item does not work properly yet
-INSERT INTO item (name, sellIn, quality) VALUES ('Conjured Mana Cake', 3, 6);
+INSERT INTO item (name, sellIn, quality) VALUES ('Conjured Mana Cake', 3, 10);
 
 COMMIT;

--- a/swift/Sources/GildedRoseApp/main.swift
+++ b/swift/Sources/GildedRoseApp/main.swift
@@ -10,7 +10,7 @@ let items = [
     Item(name: "Backstage passes to a TAFKAL80ETC concert", sellIn: 10, quality: 49),
     Item(name: "Backstage passes to a TAFKAL80ETC concert", sellIn: 5, quality: 49),
     // this conjured item does not work properly yet
-    Item(name: "Conjured Mana Cake", sellIn: 3, quality: 6),
+    Item(name: "Conjured Mana Cake", sellIn: 3, quality: 10),
 ]
 
 let app = GildedRose(items: items)

--- a/texttests/ThirtyDays/stdout.gr
+++ b/texttests/ThirtyDays/stdout.gr
@@ -21,7 +21,7 @@ Sulfuras, Hand of Ragnaros, -1, 80
 Backstage passes to a TAFKAL80ETC concert, 14, 21
 Backstage passes to a TAFKAL80ETC concert, 9, 50
 Backstage passes to a TAFKAL80ETC concert, 4, 50
-Conjured Mana Cake, 2, 5
+Conjured Mana Cake, 2, 4
 
 -------- day 2 --------
 name, sellIn, quality
@@ -33,7 +33,7 @@ Sulfuras, Hand of Ragnaros, -1, 80
 Backstage passes to a TAFKAL80ETC concert, 13, 22
 Backstage passes to a TAFKAL80ETC concert, 8, 50
 Backstage passes to a TAFKAL80ETC concert, 3, 50
-Conjured Mana Cake, 1, 4
+Conjured Mana Cake, 1, 2
 
 -------- day 3 --------
 name, sellIn, quality
@@ -45,7 +45,7 @@ Sulfuras, Hand of Ragnaros, -1, 80
 Backstage passes to a TAFKAL80ETC concert, 12, 23
 Backstage passes to a TAFKAL80ETC concert, 7, 50
 Backstage passes to a TAFKAL80ETC concert, 2, 50
-Conjured Mana Cake, 0, 3
+Conjured Mana Cake, 0, 0
 
 -------- day 4 --------
 name, sellIn, quality
@@ -57,7 +57,7 @@ Sulfuras, Hand of Ragnaros, -1, 80
 Backstage passes to a TAFKAL80ETC concert, 11, 24
 Backstage passes to a TAFKAL80ETC concert, 6, 50
 Backstage passes to a TAFKAL80ETC concert, 1, 50
-Conjured Mana Cake, -1, 1
+Conjured Mana Cake, -1, 0
 
 -------- day 5 --------
 name, sellIn, quality

--- a/texttests/ThirtyDays/stdout.gr
+++ b/texttests/ThirtyDays/stdout.gr
@@ -9,7 +9,7 @@ Sulfuras, Hand of Ragnaros, -1, 80
 Backstage passes to a TAFKAL80ETC concert, 15, 20
 Backstage passes to a TAFKAL80ETC concert, 10, 49
 Backstage passes to a TAFKAL80ETC concert, 5, 49
-Conjured Mana Cake, 3, 6
+Conjured Mana Cake, 3, 10
 
 -------- day 1 --------
 name, sellIn, quality
@@ -21,7 +21,7 @@ Sulfuras, Hand of Ragnaros, -1, 80
 Backstage passes to a TAFKAL80ETC concert, 14, 21
 Backstage passes to a TAFKAL80ETC concert, 9, 50
 Backstage passes to a TAFKAL80ETC concert, 4, 50
-Conjured Mana Cake, 2, 4
+Conjured Mana Cake, 2, 8
 
 -------- day 2 --------
 name, sellIn, quality
@@ -33,7 +33,7 @@ Sulfuras, Hand of Ragnaros, -1, 80
 Backstage passes to a TAFKAL80ETC concert, 13, 22
 Backstage passes to a TAFKAL80ETC concert, 8, 50
 Backstage passes to a TAFKAL80ETC concert, 3, 50
-Conjured Mana Cake, 1, 2
+Conjured Mana Cake, 1, 6
 
 -------- day 3 --------
 name, sellIn, quality
@@ -45,7 +45,7 @@ Sulfuras, Hand of Ragnaros, -1, 80
 Backstage passes to a TAFKAL80ETC concert, 12, 23
 Backstage passes to a TAFKAL80ETC concert, 7, 50
 Backstage passes to a TAFKAL80ETC concert, 2, 50
-Conjured Mana Cake, 0, 0
+Conjured Mana Cake, 0, 4
 
 -------- day 4 --------
 name, sellIn, quality

--- a/vbnet/GildedRoseKata/Program.vb
+++ b/vbnet/GildedRoseKata/Program.vb
@@ -47,7 +47,7 @@ Module Program
                 New Item With {
                 .Name = "Conjured Mana Cake",
                 .SellIn = 3,
-                .Quality = 6
+                .Quality = 10
                 }
                 }
         Dim app = New GildedRose(Items)

--- a/xslt/texttest_fixture.xml
+++ b/xslt/texttest_fixture.xml
@@ -13,6 +13,6 @@
         <item name="Backstage passes to a TAFKAL80ETC concert" sellin="10" quality="49" />
         <item name="Backstage passes to a TAFKAL80ETC concert" sellin="5" quality="49" />
         <!-- this conjured item does not work properly yet -->
-        <item name="Conjured Mana Cake" sellin="3" quality="6" />
+        <item name="Conjured Mana Cake" sellin="3" quality="10" />
     </items>
 </gildedrose>


### PR DESCRIPTION
The spec clearly says `"Conjured" items degrade in Quality twice as fast as normal items`. However, the texttest stdout.org shows a conjured item decreasing in quality by 1 each day. 

Merely updating `stdout.gr` would omit the test case where the `sellIn` date is past due for a conjured item, so I've also updated all the test fixtures I could find to include that case, and updated `stdout.gr` accordingly.