### PR TITLE
[PHP] Remove final keyword from Item class

### DIFF
--- a/php/src/Item.php
+++ b/php/src/Item.php
@@ -4,7 +4,7 @@ declare(strict_types=1);
 
 namespace GildedRose;
 
-final class Item implements \Stringable
+class Item implements \Stringable
 {
     public function __construct(
         public string $name,


### PR DESCRIPTION
# READ ME BEFORE SUBMITTING A PR

Please do not submit a PR with your solution to the Gilded Rose Kata. This repo is intended to be used as a starting point for the kata.

- [x] I acknowledge that this PR is not a solution to the Gilded Rose Kata, but an improvement to the template.

## Please provide your PR description below this line

This PR removes the `final` keyword from the `Item` class. As the `Item` class is not to be modified as per the spec, having it be `final` makes most elegant OOP solutions impossible.

Fixes #494 