### PR TITLE
Tests named 30 days are run over 30 days

### DIFF
--- a/csharp/ApprovalTest.cs
+++ b/csharp/ApprovalTest.cs
@@ -19,7 +19,7 @@ namespace csharp
             Console.SetOut(new StringWriter(fakeoutput));
             Console.SetIn(new StringReader("a\n"));
 
-            Program.Main(new string[] { });
+            Program.Main(new string[] { "30" });
             var output = fakeoutput.ToString();
 
             Approvals.Verify(output);

--- a/csharpcore-Verify.xunit/GildedRoseTests/ApprovalTest.cs
+++ b/csharpcore-Verify.xunit/GildedRoseTests/ApprovalTest.cs
@@ -22,7 +22,7 @@ namespace GildedRoseTests
             Console.SetOut(new StringWriter(fakeoutput));
             Console.SetIn(new StringReader("a\n"));
 
-            Program.Main(new string[] { });
+            Program.Main(new string[] { "30" });
             var output = fakeoutput.ToString();
 
             return Verifier.Verify(output);

--- a/csharpcore/GildedRoseTests/ApprovalTest.cs
+++ b/csharpcore/GildedRoseTests/ApprovalTest.cs
@@ -17,7 +17,7 @@ public class ApprovalTest
         Console.SetOut(new StringWriter(fakeOutput));
         Console.SetIn(new StringReader($"a{Environment.NewLine}"));
 
-        TextTestFixture.Main(new string[] { });
+        TextTestFixture.Main(new string[] { "30" });
         var output = fakeOutput.ToString();
 
         Approvals.Verify(output);


### PR DESCRIPTION
Pull request attending to a possible regression in the behavior of the Approval tests in DotNet 
introduced after 
https://github.com/emilybache/GildedRose-Refactoring-Kata/commit/e188faef86dd212cda5e4331d06e36f0ba76d2ef#diff-5e77a617e97d9e66a013c079bfbdb3eb0987e563b1a92aa74c2d0349bc88bb59

The Main program, used by the approval tests has a default number of Days set to 2 to support the texttests command line approval test - which is being updated to be a ubiquitous approval test adapter for any language

The tests in the DotNet targeted solutions are named ThirtyDays. 
Since they do not provide an override for the number of days, they are currently only running the business logic for 2 days.
(I believe that this means that the approval tests do not demonstrate the rule that the back stage pass quality is set to zero after sell in expires - the first instance of this condition seems to occur on day 6)

Given the tests were historically named ThrityDays, and were run over ThirtyDays, I would describe this as a regression.

This pull request adds the required parameter to the program to restore ThirtyDays for dotnet

Other languages that may also be affected this are Java and FSharp, but they are not included in this pull request