### PR TITLE
Added test helper to rust item

### DIFF
--- a/rust/src/gildedrose.rs
+++ b/rust/src/gildedrose.rs
@@ -1,4 +1,6 @@
 use std::fmt::{self, Display};
+
+#[derive(Debug, PartialEq)]
 pub struct Item {
     pub name: String,
     pub sell_in: i32,
@@ -94,6 +96,6 @@ mod tests {
         let mut rose = GildedRose::new(items);
         rose.update_quality();
 
-        assert_eq!("fixme", rose.items[0].name);
+        assert_eq!(rose.items[0], Item::new("fixme", -1, 0));
     }
 }


### PR DESCRIPTION
Add ability to assert equality on items.

# READ ME BEFORE SUBMITTING A PR

Please do not submit a PR with your solution to the Gilded Rose Kata. This repo is intended to be used as a starting point for the kata.

- [x] I acknowledge that this PR is not a solution to the Gilded Rose Kata, but an improvement to the template.

## Please provide your PR description below this line

There is a conflict in the instructions "Do not modify the item class" and the rust implementation. I think this change benefits the exercise as shown in the resulting test change. Note: only the `#[derive(Debug, PartialEq)]` part would be added to enable such test changes. The test change should not be added to keep to the spirit of the original, just a demonstration of what the change to Item would enable.
