### PR TITLE
bash: simplify texttest fixture

### DIFF
--- a/bash/texttest_fixture.sh
+++ b/bash/texttest_fixture.sh
@@ -2,11 +2,8 @@
 
 GILDED_ROSE_SCRIPT="./gilded_rose.sh"
 
-create_initial_items() {
-    local temp_file=$(mktemp)
-
-    cat <<EOF >"$temp_file"
-+5 Dexterity Vest|10|20
+# Define initial items as a multi-line string
+initial_items="+5 Dexterity Vest|10|20
 Aged Brie|2|0
 Elixir of the Mongoose|5|7
 Sulfuras, Hand of Ragnaros|0|80
@@ -14,25 +11,20 @@ Sulfuras, Hand of Ragnaros|-1|80
 Backstage passes to a TAFKAL80ETC concert|15|20
 Backstage passes to a TAFKAL80ETC concert|10|49
 Backstage passes to a TAFKAL80ETC concert|5|49
-Conjured Mana Cake|3|6
-EOF
-
-    echo "$temp_file"
-}
+Conjured Mana Cake|3|6"
 
 simulate_days() {
     local days=$1
-    local items_file=$2
+    local items="$2"
 
     for ((day = 0; day <= days; day++)); do
         echo "-------- day $day --------"
         echo "name, sellIn, quality"
 
-        cat "$items_file" | sed 's/|/, /g'
+        echo "$items" | sed 's/|/, /g'
 
-        local temp_output=$(mktemp)
-        cat "$items_file" | bash "$GILDED_ROSE_SCRIPT" >"$temp_output"
-        mv "$temp_output" "$items_file"
+        # Update the items for the next day
+        items=$(echo "$items" | bash "$GILDED_ROSE_SCRIPT")
 
         echo ""
     done
@@ -40,10 +32,6 @@ simulate_days() {
 
 echo OMGHAI!
 
-ITEMS_FILE=$(create_initial_items)
-
 DAYS_TO_SIMULATE=${1:-2}
 
-simulate_days $DAYS_TO_SIMULATE $ITEMS_FILE
-
-rm "$ITEMS_FILE"
+simulate_days $DAYS_TO_SIMULATE "$initial_items"


### PR DESCRIPTION
- [x] I acknowledge that this PR is not a solution to the Gilded Rose Kata, but an improvement to the template.

## Please provide your PR description below this line

bash texttest fixture: use a variable instead of a temp file to hold the items state.