### PR TITLE
[Refactor] .NET Core Templates - Update Framework and Libraries

### DIFF
--- a/csharpcore-Verify.xunit/GildedRose/GildedRose.csproj
+++ b/csharpcore-Verify.xunit/GildedRose/GildedRose.csproj
@@ -2,7 +2,7 @@
 
   <PropertyGroup>
     <OutputType>Exe</OutputType>
-    <TargetFramework>net7.0</TargetFramework>
+    <TargetFramework>net8.0</TargetFramework>
     <StartupObject>GildedRoseKata.Program</StartupObject>
   </PropertyGroup>
 

--- a/csharpcore-Verify.xunit/GildedRoseTests/ApprovalTest.cs
+++ b/csharpcore-Verify.xunit/GildedRoseTests/ApprovalTest.cs
@@ -12,7 +12,6 @@ using Xunit;
 
 namespace GildedRoseTests
 {
-    [UsesVerify]
     public class ApprovalTest
     {
         [Fact]

--- a/csharpcore-Verify.xunit/GildedRoseTests/GildedRoseTests.csproj
+++ b/csharpcore-Verify.xunit/GildedRoseTests/GildedRoseTests.csproj
@@ -1,15 +1,21 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
 
     <PropertyGroup>
-        <TargetFramework>net7.0</TargetFramework>
+        <TargetFramework>net8.0</TargetFramework>
         <IsPackable>false</IsPackable>
     </PropertyGroup>
     <ItemGroup>
-        <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.0.0" />
-        <PackageReference Include="Verify.Xunit" Version="14.11.4" />
-        <PackageReference Include="xunit" Version="2.4.1" />
-        <PackageReference Include="xunit.runner.visualstudio" Version="2.4.3" />
-        <PackageReference Include="coverlet.collector" Version="3.1.0" />
+        <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.8.0" />
+        <PackageReference Include="Verify.Xunit" Version="23.1.0" />
+        <PackageReference Include="xunit" Version="2.6.6" />
+        <PackageReference Include="xunit.runner.visualstudio" Version="2.5.6">
+          <PrivateAssets>all</PrivateAssets>
+          <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
+        </PackageReference>
+        <PackageReference Include="coverlet.collector" Version="6.0.0">
+          <PrivateAssets>all</PrivateAssets>
+          <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
+        </PackageReference>
     </ItemGroup>
 
     <ItemGroup>

--- a/csharpcore-Verify.xunit/GildedRoseTests/GildedRoseTests.csproj
+++ b/csharpcore-Verify.xunit/GildedRoseTests/GildedRoseTests.csproj
@@ -9,12 +9,12 @@
         <PackageReference Include="Verify.Xunit" Version="23.1.0" />
         <PackageReference Include="xunit" Version="2.6.6" />
         <PackageReference Include="xunit.runner.visualstudio" Version="2.5.6">
-          <PrivateAssets>all</PrivateAssets>
-          <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
+            <PrivateAssets>all</PrivateAssets>
+            <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
         </PackageReference>
         <PackageReference Include="coverlet.collector" Version="6.0.0">
-          <PrivateAssets>all</PrivateAssets>
-          <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
+            <PrivateAssets>all</PrivateAssets>
+            <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
         </PackageReference>
     </ItemGroup>
 

--- a/csharpcore/GildedRose/GildedRose.csproj
+++ b/csharpcore/GildedRose/GildedRose.csproj
@@ -1,7 +1,7 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFramework>net7.0</TargetFramework>
+    <TargetFramework>net8.0</TargetFramework>
   </PropertyGroup>
 
 </Project>

--- a/csharpcore/GildedRoseTests/ApprovalTest.cs
+++ b/csharpcore/GildedRoseTests/ApprovalTest.cs
@@ -1,17 +1,16 @@
 using System;
 using System.IO;
 using System.Text;
-using ApprovalTests;
-using ApprovalTests.Reporters;
+using System.Threading.Tasks;
 using NUnit.Framework;
+using VerifyNUnit;
 
 namespace GildedRoseTests;
 
-[UseReporter(typeof(DiffReporter))]
 public class ApprovalTest
 {
     [Test]
-    public void ThirtyDays()
+    public Task ThirtyDays()
     {
         var fakeOutput = new StringBuilder();
         Console.SetOut(new StringWriter(fakeOutput));
@@ -20,6 +19,6 @@ public class ApprovalTest
         TextTestFixture.Main(new string[] { "30" });
         var output = fakeOutput.ToString();
 
-        Approvals.Verify(output);
+        return Verifier.Verify(output);
     }
 }

--- a/csharpcore/GildedRoseTests/GildedRoseTest.cs
+++ b/csharpcore/GildedRoseTests/GildedRoseTest.cs
@@ -12,6 +12,6 @@ public class GildedRoseTest
         var items = new List<Item> { new Item { Name = "foo", SellIn = 0, Quality = 0 } };
         var app = new GildedRose(items);
         app.UpdateQuality();
-        Assert.AreEqual("fixme", items[0].Name);
+        Assert.That(items[0].Name, Is.EqualTo("fixme"));
     }
 }

--- a/csharpcore/GildedRoseTests/GildedRoseTests.csproj
+++ b/csharpcore/GildedRoseTests/GildedRoseTests.csproj
@@ -1,23 +1,24 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
 
-    <PropertyGroup>
-        <OutputType>Exe</OutputType>
-        <TargetFramework>net7.0</TargetFramework>
-        <StartupObject>GildedRoseTests.TextTestFixture</StartupObject>
-    </PropertyGroup>
+	<PropertyGroup>
+		<OutputType>Exe</OutputType>
+		<TargetFramework>net8.0</TargetFramework>
+		<StartupObject>GildedRoseTests.TextTestFixture</StartupObject>
+	</PropertyGroup>
 
-    <ItemGroup>
-        <PackageReference Include="ApprovalTests" Version="5.9.0" />
-        <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.7.2" />
-        <PackageReference Include="NUnit" Version="3.13.3" />
-        <PackageReference Include="coverlet.collector" Version="6.0.0"><IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
-<PrivateAssets>all</PrivateAssets>
-</PackageReference>
-        <PackageReference Include="NUnit3TestAdapter" Version="4.5.0" />
-    </ItemGroup>
+	<ItemGroup>
+		<PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.8.0" />
+		<PackageReference Include="NUnit" Version="4.0.1" />
+		<PackageReference Include="coverlet.collector" Version="6.0.0">
+			<IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
+			<PrivateAssets>all</PrivateAssets>
+		</PackageReference>
+		<PackageReference Include="NUnit3TestAdapter" Version="4.5.0" />
+		<PackageReference Include="Verify.NUnit" Version="23.1.0" />
+	</ItemGroup>
 
-    <ItemGroup>
-        <ProjectReference Include="..\GildedRose\GildedRose.csproj" />
-    </ItemGroup>
+	<ItemGroup>
+		<ProjectReference Include="..\GildedRose\GildedRose.csproj" />
+	</ItemGroup>
 
 </Project>

--- a/csharpcore/GildedRoseTests/GildedRoseTests.csproj
+++ b/csharpcore/GildedRoseTests/GildedRoseTests.csproj
@@ -1,24 +1,24 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
 
-	<PropertyGroup>
-		<OutputType>Exe</OutputType>
-		<TargetFramework>net8.0</TargetFramework>
-		<StartupObject>GildedRoseTests.TextTestFixture</StartupObject>
-	</PropertyGroup>
+    <PropertyGroup>
+        <OutputType>Exe</OutputType>
+        <TargetFramework>net8.0</TargetFramework>
+        <StartupObject>GildedRoseTests.TextTestFixture</StartupObject>
+    </PropertyGroup>
 
-	<ItemGroup>
-		<PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.8.0" />
-		<PackageReference Include="NUnit" Version="4.0.1" />
-		<PackageReference Include="coverlet.collector" Version="6.0.0">
-			<IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
-			<PrivateAssets>all</PrivateAssets>
-		</PackageReference>
-		<PackageReference Include="NUnit3TestAdapter" Version="4.5.0" />
-		<PackageReference Include="Verify.NUnit" Version="23.1.0" />
-	</ItemGroup>
+    <ItemGroup>
+        <PackageReference Include="Verify.NUnit" Version="23.1.0" />
+        <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.8.0" />
+        <PackageReference Include="NUnit" Version="4.0.1" />
+        <PackageReference Include="coverlet.collector" Version="6.0.0">
+		    <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
+		    <PrivateAssets>all</PrivateAssets>
+        </PackageReference>
+        <PackageReference Include="NUnit3TestAdapter" Version="4.5.0" />
+    </ItemGroup>
 
-	<ItemGroup>
-		<ProjectReference Include="..\GildedRose\GildedRose.csproj" />
-	</ItemGroup>
+    <ItemGroup>
+        <ProjectReference Include="..\GildedRose\GildedRose.csproj" />
+    </ItemGroup>
 
 </Project>

--- a/csharpcore/GildedRoseTests/GildedRoseTests.csproj
+++ b/csharpcore/GildedRoseTests/GildedRoseTests.csproj
@@ -11,8 +11,8 @@
         <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.8.0" />
         <PackageReference Include="NUnit" Version="4.0.1" />
         <PackageReference Include="coverlet.collector" Version="6.0.0">
-		    <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
-		    <PrivateAssets>all</PrivateAssets>
+            <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
+            <PrivateAssets>all</PrivateAssets>
         </PackageReference>
         <PackageReference Include="NUnit3TestAdapter" Version="4.5.0" />
     </ItemGroup>


### PR DESCRIPTION
# READ ME BEFORE SUBMITTING A PR

Please do not submit a PR with your solution to the Gilded Rose Kata. This repo is intended to be used as a starting point for the kata.

- [x] I acknowledge that this PR is not a solution to the Gilded Rose Kata, but an improvement to the template.

## Please provide your PR description below this line

List of changes and reasoning:
- Update the .NET Core solutions to the latest major version 8
- Update all packages to their latest versions and accommodate for any breaking changes
  - NUnit legacy assertions are replaced by the new assertions API, see https://docs.nunit.org/articles/nunit/release-notes/Nunit4.0-MigrationGuide.html.
  - `[UsesVerify]` attribute deprecated in the latest Verify lib versions
- In the NUnit version, replace https://github.com/approvals/ApprovalTests.Net for https://github.com/VerifyTests/Verify as recommended by the lib maintainers. This is the same library used in the Xunit version.