### PR TITLE
Update csharp.csproj

### DIFF
--- a/csharp/csharp.csproj
+++ b/csharp/csharp.csproj
@@ -1,6 +1,6 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
-    <TargetFramework>net6.0</TargetFramework>
+    <TargetFramework>net8.0</TargetFramework>
     <OutputType>Exe</OutputType>
     <GenerateAssemblyInfo>false</GenerateAssemblyInfo>
     <GenerateProgramFile>false</GenerateProgramFile>
@@ -18,15 +18,14 @@
     <PackageReference Include="ApprovalUtilities" Version="5.9.0" />
     <PackageReference Include="DiffEngine" Version="12.2.1" />
     <PackageReference Include="EmptyFiles" Version="4.5.0" />
-    <PackageReference Include="Microsoft.CSharp" Version="4.7.0" />
     <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.7.2" />
     <PackageReference Include="NUnit" Version="3.13.3" />
     <PackageReference Include="NUnit3TestAdapter" Version="4.5.0" />
-    <PackageReference Include="System.Data.DataSetExtensions" Version="4.5.0" />
     <PackageReference Include="System.Data.SqlClient" Version="4.8.5" />
     <PackageReference Include="TextCopy" Version="6.2.1" />
-    <PackageReference Include="System.CodeDom" Version="6.0.0" />
-    <PackageReference Include="System.Management" Version="6.0.2" />
+    <PackageReference Include="Microsoft.CSharp" Version="4.7.0" />
+    <PackageReference Include="System.CodeDom" Version="8.0.0" />
+    <PackageReference Include="System.Management" Version="8.0.0" />
     <PackageReference Include="System.Runtime.CompilerServices.Unsafe" Version="6.0.0" />
     <PackageReference Include="System.Security.AccessControl" Version="6.0.0" />
   </ItemGroup>


### PR DESCRIPTION
upgrade to .Net8.0 via Microsoft's command line upgrade-assistant.  .Net6.0 support ends in November 2024.
Other .Net/C# projects in the GildedRose repo are already at .Net8.0

# READ ME BEFORE SUBMITTING A PR

Please do not submit a PR with your solution to the Gilded Rose Kata. This repo is intended to be used as a starting point for the kata.

- [x] I acknowledge that this PR is not a solution to the Gilded Rose Kata, but an improvement to the template.

## Please provide your PR description below this line

upgrade to .Net8.0 via Microsoft's command line upgrade-assistant.  .Net6.0 support ends in November 2024.
Other .Net/C# projects in the GildedRose repo are already at .Net8.0
