### PR TITLE
fix deprecated usage of assertEquals

### DIFF
--- a/python/test_gilded_rose.py
+++ b/python/test_gilded_rose.py
@@ -9,7 +9,7 @@ class GildedRoseTest(unittest.TestCase):
         items = [Item("foo", 0, 0)]
         gilded_rose = GildedRose(items)
         gilded_rose.update_quality()
-        self.assertEquals("fixme", items[0].name)
+        self.assertEqual("fixme", items[0].name)
 
         
 if __name__ == '__main__':


### PR DESCRIPTION
should be `assertEqual`, as the other form has been deprecated since 2010 and since been removed

# READ ME BEFORE SUBMITTING A PR

Please do not submit a PR with your solution to the Gilded Rose Kata. This repo is intended to be used as a starting point for the kata.

- [x] I acknowledge that this PR is not a solution to the Gilded Rose Kata, but an improvement to the template.

## Please provide your PR description below this line

Original issue that triggered `assertEquals` being deprecated: https://bugs.python.org/issue9424 