### PR TITLE
fix small leftovers for csharpcore porting to .Net 8.0

### DIFF
--- a/csharpcore/README.md
+++ b/csharpcore/README.md
@@ -9,7 +9,7 @@ Use your normal build tools.
 For e.g. 10 days:
 
 ```
-GildedRoseTests/bin/Debug/net7.0/GildedRoseTests 10
+GildedRoseTests/bin/Debug/net8.0/GildedRoseTests 10
 ```
 
 You should make sure the command shown above works when you execute it in a terminal before trying to use TextTest (see below). If your tooling has placed the executable somewhere else, you will need to adjust the path above.
@@ -19,5 +19,5 @@ You should make sure the command shown above works when you execute it in a term
 
 There are instructions in the [TextTest Readme](../texttests/README.md) for setting up TextTest. You will need to specify the GildedRoseTests executable and interpreter in [config.gr](../texttests/config.gr). Uncomment this line:
 
-    executable:${TEXTTEST_HOME}/csharpcore/GildedRoseTests/bin/Debug/net7.0/GildedRoseTests
+    executable:${TEXTTEST_HOME}/csharpcore/GildedRoseTests/bin/Debug/net8.0/GildedRoseTests
 

--- a/texttests/config.gr
+++ b/texttests/config.gr
@@ -32,7 +32,7 @@ executable:${TEXTTEST_HOME}/ruby/texttest_fixture.rb
 interpreter:ruby
 
 # Settings for the C# Core version
-#executable:${TEXTTEST_HOME}/csharpcore/GildedRoseTests/bin/Debug/net7.0/GildedRoseTests
+#executable:${TEXTTEST_HOME}/csharpcore/GildedRoseTests/bin/Debug/net8.0/GildedRoseTests
 
 # Settings for the Perl version
 #executable:${TEXTTEST_HOME}/perl/texttest_fixture.pl


### PR DESCRIPTION
# READ ME BEFORE SUBMITTING A PR

Please do not submit a PR with your solution to the Gilded Rose Kata. This repo is intended to be used as a starting point for the kata.

- [x] I acknowledge that this PR is not a solution to the Gilded Rose Kata, but an improvement to the template.

## Please provide your PR description below this line

`csharpcore` was previously ported from .Net 7.0 to .Net 8.0. This PR only fixes a couple of references to the old .Net version (and directory) in the docs and `texttests/config.gr`.
