### PR TITLE
swift: fix warning about executableTarget

### DIFF
--- a/swift/Package.swift
+++ b/swift/Package.swift
@@ -15,7 +15,7 @@ let package = Package(
             name: "GildedRose",
             dependencies: []
         ),
-        .target(
+        .executableTarget(
             name: "GildedRoseApp",
             dependencies: ["GildedRose"]
         ),


### PR DESCRIPTION
# READ ME BEFORE SUBMITTING A PR

Please do not submit a PR with your solution to the Gilded Rose Kata. This repo is intended to be used as a starting point for the kata.

- [x] I acknowledge that this PR is not a solution to the Gilded Rose Kata, but an improvement to the template.

## Please provide your PR description below this line

Fixes warning due to changes in Swift. The warning says:

'GildedRoseApp' was identified as an executable target given the presence of a 'main.swift' file. Starting with tools version 5.4.0 executable targets should be declared as 'executableTarget()'