### PR TITLE
swift: use && instead of , for beginners and for automated mutation

### DIFF
--- a/swift/Sources/GildedRose/GildedRose.swift
+++ b/swift/Sources/GildedRose/GildedRose.swift
@@ -7,7 +7,7 @@ public class GildedRose {
 
     public func updateQuality() {
         for i in 0 ..< items.count {
-            if items[i].name != "Aged Brie", items[i].name != "Backstage passes to a TAFKAL80ETC concert" {
+            if items[i].name != "Aged Brie" && items[i].name != "Backstage passes to a TAFKAL80ETC concert" {
                 if items[i].quality > 0 {
                     if items[i].name != "Sulfuras, Hand of Ragnaros" {
                         items[i].quality = items[i].quality - 1


### PR DESCRIPTION
# READ ME BEFORE SUBMITTING A PR

Please do not submit a PR with your solution to the Gilded Rose Kata. This repo is intended to be used as a starting point for the kata.

- [x] I acknowledge that this PR is not a solution to the Gilded Rose Kata, but an improvement to the template.

## Please provide your PR description below this line

`&&` is familiar to more people than Swift's comma operator. I'd like to change it back.

Benefits:
- Easier for folks newer to Swift
- Better automated mutation from Muter tool