### PR TITLE
Update ApprovalTest fix the deprecated method call

### DIFF
--- a/php/tests/ApprovalTest.php
+++ b/php/tests/ApprovalTest.php
@@ -39,6 +39,6 @@ class ApprovalTest extends TestCase
 
         $output = ob_get_clean();
 
-        Approvals::approveString($output);
+        Approvals::verifyString($output);
     }
 }


### PR DESCRIPTION
Hello again,

I've just realized that one of the method calls in the ApprovalTest file is deprecated. This PR fixes this deprecation.
