### PR TITLE
Enable texttest to run in the Kotlin project

### DIFF
--- a/Kotlin/build.gradle.kts
+++ b/Kotlin/build.gradle.kts
@@ -24,6 +24,14 @@ tasks.test {
 	}
 }
 
+tasks.register<JavaExec>("texttest") {
+	description = "Allow you to run text-based approval tests with texttest"
+	group = JavaBasePlugin.BUILD_TASK_NAME
+	mainClass.set("com.gildedrose.TexttestFixtureKt")
+	classpath = sourceSets["test"].runtimeClasspath
+	args("30")
+}
+
 // config JVM target to 1.8 for kotlin compilation tasks
 tasks.withType<KotlinCompile>().configureEach {
 	kotlinOptions.jvmTarget = "1.8"


### PR DESCRIPTION
# READ ME BEFORE SUBMITTING A PR

Please do not submit a PR with your solution to the Gilded Rose Kata. This repo is intended to be used as a starting point for the kata.

- [x] I acknowledge that this PR is not a solution to the Gilded Rose Kata, but an improvement to the template.
- [x] I acknowledge that I have read [CONTRIBUTING.md](https://github.com/emilybache/GildedRose-Refactoring-Kata/blob/main/CONTRIBUTING.md)

## Please provide your PR description below this line

If you clone the repo, navigate to the Kotlin directory and run `./gradlew -q text`, it fails because gradle doesn't have a `text` task. This PR adds this task. 

I translated the task found in the Java build.gradle to maintain the behaviour, and now `./gradlew -q text` works!


