### PR TITLE
Fix incorrect Ruby syntax

### DIFF
--- a/ruby/texttest_fixture.rb
+++ b/ruby/texttest_fixture.rb
@@ -4,16 +4,16 @@ require File.join(File.dirname(__FILE__), 'gilded_rose')
 
 puts "OMGHAI!"
 items = [
-  Item.new(name="+5 Dexterity Vest", sell_in=10, quality=20),
-  Item.new(name="Aged Brie", sell_in=2, quality=0),
-  Item.new(name="Elixir of the Mongoose", sell_in=5, quality=7),
-  Item.new(name="Sulfuras, Hand of Ragnaros", sell_in=0, quality=80),
-  Item.new(name="Sulfuras, Hand of Ragnaros", sell_in=-1, quality=80),
-  Item.new(name="Backstage passes to a TAFKAL80ETC concert", sell_in=15, quality=20),
-  Item.new(name="Backstage passes to a TAFKAL80ETC concert", sell_in=10, quality=49),
-  Item.new(name="Backstage passes to a TAFKAL80ETC concert", sell_in=5, quality=49),
+  Item.new("+5 Dexterity Vest", 10, 20),
+  Item.new("Aged Brie", 2, 0),
+  Item.new("Elixir of the Mongoose", 5, 7),
+  Item.new("Sulfuras, Hand of Ragnaros", 0, 80),
+  Item.new("Sulfuras, Hand of Ragnaros", -1, 80),
+  Item.new("Backstage passes to a TAFKAL80ETC concert", 15, 20),
+  Item.new("Backstage passes to a TAFKAL80ETC concert", 10, 49),
+  Item.new("Backstage passes to a TAFKAL80ETC concert", 5, 49),
   # This Conjured item does not work properly yet
-  Item.new(name="Conjured Mana Cake", sell_in=3, quality=6), # <-- :O
+  Item.new("Conjured Mana Cake", 3, 6), # <-- :O
 ]
 
 days = 2


### PR DESCRIPTION
# READ ME BEFORE SUBMITTING A PR

Please do not submit a PR with your solution to the Gilded Rose Kata. This repo is intended to be used as a starting point for the kata.

- [x] I acknowledge that this PR is not a solution to the Gilded Rose Kata, but an improvement to the template.
- [x] I acknowledge that I have read [CONTRIBUTING.md](https://github.com/emilybache/GildedRose-Refactoring-Kata/blob/main/CONTRIBUTING.md)

## Please provide your PR description below this line

It looks like the Ruby example was based on the Python one, but this is not the correct syntax for keywords arguments in Ruby. It doesn't cause an error, but it also doesn't provide any benefit, since the argument names aren't validated.

If keyword arguments were used, it would look like:

`Item.new(name: "Aged Brie", sell_in: 2, quality: 0),`

and the initializer would need to be updated.