### PR TITLE
Omit parentheses in no‑arg defs

### DIFF
--- a/ruby/gilded_rose.rb
+++ b/ruby/gilded_rose.rb
@@ -62,7 +62,7 @@ class Item
     @quality = quality
   end
 
-  def to_s()
+  def to_s
     "#{@name}, #{@sell_in}, #{@quality}"
   end
 end


### PR DESCRIPTION
# READ ME BEFORE SUBMITTING A PR

Please do not submit a PR with your solution to the Gilded Rose Kata. This repo is intended to be used as a starting point for the kata.

- [x] I acknowledge that this PR is not a solution to the Gilded Rose Kata, but an improvement to the template.
- [x] I acknowledge that I have read [CONTRIBUTING.md](https://github.com/emilybache/GildedRose-Refactoring-Kata/blob/main/CONTRIBUTING.md)

## Please provide your PR description below this line

This PR removes RuboCop offense for the unnecessary parentheses in `Item` class method `to_s`. Since the `Item` class is not supposed to be touched, it is best to make it fully compliant with Ruby coding style.

The offense in verbatim is as follows.
```
gilded_rose.rb:65:11: C: [Correctable] Style/DefWithParentheses: Omit the parentheses in defs when the method doesn't accept any arguments.
  def to_s()
          ^^
```
