### PR TITLE
Fix GitHub Actions condition: check repository owner instead of (non-…

### DIFF
--- a/.github/workflows/pr-validation.yml
+++ b/.github/workflows/pr-validation.yml
@@ -5,8 +5,11 @@ on:
 
 jobs:
   task-check:
+    # github.event.repository.name only contains 'GildedRose-Refactoring-Kata' (no owner)!
+    # we could check owner and name if: github.repository == 'emilybache/GildedRose-Refactoring-Kata'
+    # but checking owner is enough/better/more stable
     # Only run from the base repository
-    if: github.event.repository.name == 'emilybache/GildedRose-Refactoring-Kata'
+    if: github.repository_owner == 'emilybache'
     runs-on: ubuntu-latest
     permissions:
       issues: write


### PR DESCRIPTION
- [X] I acknowledge that this PR is not a solution to the Gilded Rose Kata, but an improvement to the template.
- [X] acknowledge that I have read [CONTRIBUTING.md](https://github.com/emilybache/GildedRose-Refactoring-Kata/blob/main/CONTRIBUTING.md)

## Please provide your PR description below this line

Fix GitHub Actions condition: check repository owner instead of repo name

The previous condition compared `github.event.repository.name` to
`emilybache/GildedRose-Refactoring-Kata`, which can never match because
`repository.name` does not include the owner.

Switch to checking `github.repository_owner` to reliably ensure the
workflow only runs in the upstream repository and not in forks.