### PR TITLE
chore: show vitest coverage in JetBrains IDEs (TypeScript)

### DIFF
--- a/TypeScript/vitest.config.ts
+++ b/TypeScript/vitest.config.ts
@@ -8,7 +8,7 @@ export default defineConfig({
     include: ['test/vitest/**/*.{spec,test}.{js,ts}'],
     coverage: {
       provider: 'istanbul',
-      reporter: ['text', 'html']
+      reporter: ['text', 'html', 'lcov']
     }
   },
 });


### PR DESCRIPTION
# READ ME BEFORE SUBMITTING A PR

Please do not submit a PR with your solution to the Gilded Rose Kata. This repo is intended to be used as a starting point for the kata.

- [x] I acknowledge that this PR is not a solution to the Gilded Rose Kata, but an improvement to the template.
- [x] I acknowledge that I have read [CONTRIBUTING.md](https://github.com/emilybache/GildedRose-Refactoring-Kata/blob/main/CONTRIBUTING.md)

## Please provide your PR description below this line

when solving the kata with code coverage approaches, the code coverage is not shown in WebStorm (and probably other JetBrains IDEs) when vitest is used. This PR fixes that.